### PR TITLE
flag improvements and docs:

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![CI](https://github.com/openzim/warc2zim/workflows/CI/badge.svg)
 [![Docker Build Status](https://img.shields.io/docker/build/openzim/warc2zim)](https://hub.docker.com/r/openzim/warc2zim)
 [![codecov](https://codecov.io/gh/openzim/warc2zim/branch/master/graph/badge.svg)](https://codecov.io/gh/openzim/warc2zim)
+[![CodeFactor](https://www.codefactor.io/repository/github/openzim/warc2zim/badge)](https://www.codefactor.io/repository/github/openzim/warc2zim)
 
 warc2zim provides a way to convert WARC files to ZIM, storing the WARC payload and WARC+HTTP headers separately.
 
@@ -10,9 +11,34 @@ that can render its content in a modern browser.
 
 ## Usage
 
-Ex: `warc2zim ./path/to/myarchive.warc -u https://example.com/`
+Example:
 
-The above will create a ZIM file `./path/to/myarchive.zim` with `https://example.com/` set as the main page.
+```
+warc2zim ./path/to/myarchive.warc --output /output --name myarchive.zim -u https://example.com/
+```
+
+The above will create a ZIM file `/output/myarchive.zim` with `https://example.com/` set as the main page.
+
+## URL Filtering
+
+By default, only URLs from domain of the main page and subdomains are included, eg. only `*.example.com` urls in the above example.
+
+This allows for filtering out URLs that may be out of scope (eg. ads, social media trackers).
+
+To specify a different top-level domain, use the `--include-domains`/ `-i` flag for each domain, eg. if main page is on a subdomain, `https://subdomain.example.com/` but all URLs from `*.example.com` should be included, use:
+
+
+```
+warc2zim myarchive.warc --name myarchive -i example.com -u https://subdomain.example.com/starting/page.html
+```
+
+
+To simply include all urls, use the `--include-all` / `-a` flag:
+
+```
+warc2zim myarchive.warc --name myarchive -a -u https://someother.example.com/page.html
+```
+
 
 See `warc2zim -h` for other options.
 
@@ -26,6 +52,10 @@ For `response` records, the WARC + HTTP headers are stored under `H/<url>` while
 For `resource` records, the WARC headers are stored under `H/<url>` while the payload is stored under `A/<url>`. (Three are no HTTP headers for resource records).
 
 For `revisit` records, the WARC + optional HTTP headers are stored under `H/<url>`, while no payload record is created.
+
+
+If the payload `A/<url>` is zero-length, the record is omitted to conform to ZIM specifications of not storing empty records.
+
 
 ### Duplicate URIs
 

--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -2,9 +2,8 @@
 # -*- coding: utf-8 -*-
 # vim: ai ts=4 sts=4 et sw=4 nu
 
-import tempfile
-import shutil
 import os
+import time
 from io import BytesIO
 
 import pytest
@@ -37,6 +36,9 @@ CMDLINES = [
 ]
 
 
+TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
+
+
 @pytest.fixture(params=CMDLINES, ids=[" ".join(cmds) for cmds in CMDLINES])
 def cmdline(request):
     return request.param
@@ -44,21 +46,6 @@ def cmdline(request):
 
 # ============================================================================
 class TestWarc2Zim(object):
-    @classmethod
-    def setup_class(cls):
-        cls.root_dir = os.path.realpath(tempfile.mkdtemp())
-        cls.orig_cwd = os.getcwd()
-        os.chdir(cls.root_dir)
-
-        cls.test_data_dir = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "data"
-        )
-
-    @classmethod
-    def teardown_class(cls):
-        os.chdir(cls.orig_cwd)
-        shutil.rmtree(cls.root_dir)
-
     def list_articles(self, zimfile):
         zim_fh = libzim.reader.File(zimfile)
         for x in range(zim_fh.article_count):
@@ -144,13 +131,17 @@ class TestWarc2Zim(object):
 
                 warc_urls.add(url)
 
-    def test_warc_to_zim_specify_params_and_metadata(self):
+    def test_warc_to_zim_specify_params_and_metadata(self, tmp_path):
         zim_output = "zim-out-filename.zim"
         warc2zim(
             [
                 "-v",
-                os.path.join(self.test_data_dir, "example-response.warc"),
-                "-o",
+                os.path.join(TEST_DATA_DIR, "example-response.warc"),
+                "--name",
+                "example-response",
+                "--output",
+                str(tmp_path),
+                "--zim-file",
                 zim_output,
                 "-r",
                 "https://cdn.jsdelivr.net/npm/@webrecorder/wabac@2.1.0-dev.3/dist/",
@@ -166,6 +157,8 @@ class TestWarc2Zim(object):
                 "Some Title",
             ]
         )
+
+        zim_output = tmp_path / zim_output
 
         assert os.path.isfile(zim_output)
 
@@ -184,6 +177,7 @@ class TestWarc2Zim(object):
             "A/sw.js": "sw.js",
             "A/topFrame.html": "topFrame.html",
             # ZIM metadata
+            "M/Compression": "Compression",
             "M/Counter": "Counter",
             "M/Creator": "Creator",
             "M/Date": "Date",
@@ -204,36 +198,40 @@ class TestWarc2Zim(object):
         assert self.get_article(zim_output, "M/Tags") == b"some;foo;bar"
         assert self.get_article(zim_output, "M/Title") == b"Some Title"
 
-    def test_warc_to_zim(self, cmdline):
+    def test_warc_to_zim(self, cmdline, tmp_path):
         filename = cmdline[0]
 
         # cwd is set to root dir
-        warcfile = os.path.join(".", filename)
-
-        # copy test WARCs to test dir to test different output scenarios
-        shutil.copy(os.path.join(self.test_data_dir, filename), warcfile)
+        warcfile = os.path.join(TEST_DATA_DIR, filename)
 
         # warc2zim([warcfile] + cmdline[1:])
+        cmdline.extend(["--output", str(tmp_path), "--name", cmdline[0]])
+
         warc2zim(cmdline)
 
-        zimfile, ext = os.path.splitext(warcfile)
-        zimfile += ".zim"
+        zimfile = cmdline[0] + "_" + time.strftime("%Y-%m") + ".zim"
 
-        self.verify_warc_and_zim(warcfile, zimfile)
+        self.verify_warc_and_zim(warcfile, tmp_path / zimfile)
 
-    def test_same_domain_only(self):
+    def test_same_domain_only(self, tmp_path):
         zim_output = "same-domain.zim"
         warc2zim(
             [
-                os.path.join(self.test_data_dir, "example-revisit.warc.gz"),
+                os.path.join(TEST_DATA_DIR, "example-revisit.warc.gz"),
                 "--favicon",
                 "http://example.com/favicon.ico",
                 "--lang",
                 "eng",
-                "-o",
+                "--zim-file",
                 zim_output,
+                "--name",
+                "same-domain",
+                "--output",
+                str(tmp_path),
             ]
         )
+
+        zim_output = tmp_path / zim_output
 
         for article in self.list_articles(zim_output):
             url = article.longurl
@@ -241,17 +239,23 @@ class TestWarc2Zim(object):
             if url.startswith("A/") and len(url.split("/")) > 2:
                 assert url.startswith("A/example.com/")
 
-    def test_include_domains_favicon_and_language(self):
+    def test_include_domains_favicon_and_language(self, tmp_path):
         zim_output = "spt.zim"
         warc2zim(
             [
-                os.path.join(self.test_data_dir, "single-page-test.warc"),
+                os.path.join(TEST_DATA_DIR, "single-page-test.warc"),
                 "-i",
                 "reseau-canope.fr",
-                "-o",
+                "--output",
+                str(tmp_path),
+                "--zim-file",
                 zim_output,
+                "--name",
+                "spt",
             ]
         )
+
+        zim_output = tmp_path / zim_output
 
         for article in self.list_articles(zim_output):
             url = article.longurl
@@ -270,16 +274,20 @@ class TestWarc2Zim(object):
             == "A/lesfondamentaux.reseau-canope.fr/fileadmin/template/img/favicon.ico"
         )
 
-    def test_error_bad_replay_viewer_url(self):
+    def test_error_bad_replay_viewer_url(self, tmp_path):
         zim_output_not_created = "zim-out-not-created.zim"
         with pytest.raises(Exception) as e:
             warc2zim(
                 [
                     "-v",
-                    os.path.join(self.test_data_dir, "example-response.warc"),
+                    os.path.join(TEST_DATA_DIR, "example-response.warc"),
                     "-r",
                     "x-invalid-x",
-                    "-o",
+                    "--output",
+                    str(tmp_path),
+                    "--name",
+                    "bad",
+                    "--zim-file",
                     zim_output_not_created,
                 ]
             )
@@ -287,16 +295,20 @@ class TestWarc2Zim(object):
         # zim file should not have been created since replay viewer could not be loaded
         assert not os.path.isfile(zim_output_not_created)
 
-    def test_error_bad_main_page(self):
+    def test_error_bad_main_page(self, tmp_path):
         zim_output_not_created = "zim-out-not-created.zim"
         with pytest.raises(Exception) as e:
             warc2zim(
                 [
                     "-v",
-                    os.path.join(self.test_data_dir, "example-response.warc"),
+                    os.path.join(TEST_DATA_DIR, "example-response.warc"),
                     "-u",
                     "https://no-such-url.example.com",
-                    "-o",
+                    "--output",
+                    str(tmp_path),
+                    "--name",
+                    "bad",
+                    "--zim-file",
                     zim_output_not_created,
                 ]
             )

--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -199,17 +199,18 @@ class TestWarc2Zim(object):
         assert self.get_article(zim_output, "M/Title") == b"Some Title"
 
     def test_warc_to_zim(self, cmdline, tmp_path):
+        # intput filename
         filename = cmdline[0]
 
-        # cwd is set to root dir
+        # set intput filename (first arg) to absolute path from test dir
         warcfile = os.path.join(TEST_DATA_DIR, filename)
+        cmdline[0] = warcfile
 
-        # warc2zim([warcfile] + cmdline[1:])
-        cmdline.extend(["--output", str(tmp_path), "--name", cmdline[0]])
+        cmdline.extend(["--output", str(tmp_path), "--name", filename])
 
         warc2zim(cmdline)
 
-        zimfile = cmdline[0] + "_" + time.strftime("%Y-%m") + ".zim"
+        zimfile = filename + "_" + time.strftime("%Y-%m") + ".zim"
 
         self.verify_warc_and_zim(warcfile, tmp_path / zimfile)
 


### PR DESCRIPTION
- name flags: use --name, --zim-file, --output convention for output, per spec in #4
- use zstd compression (#49)
- add codefactor badge to README (#14)
- update README with more info on domain filtering
- tests: use tmp_path fixture for temp dir