### PR TITLE
scraperlib 3.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Using scraperlib 2.1.0
-- Using wabac.js 2.15.5
+- Using scraperlib 3.1.1, openZIM metatadata now always set, using default if missing
+- Using wabac.js 2.16.5
 
 ## [1.5.1] - 2023-02-06
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,9 @@
-warcio>=1.7.4,<1.8
-requests>=2.25.1,<3.0
-beautifulsoup4>=4.9.3,<4.10
-zimscraperlib>=2.1.0,<2.2
-Babel>=2.9,<3.0
-jinja2>=2.11,<3.0
+warcio==1.7.4
+requests==2.31.0
+beautifulsoup4==4.9.3
+zimscraperlib==3.1.1
+Babel==2.12.1
+jinja2==3.1.2
 # to support possible brotli content in warcs
 brotlipy==0.7.0
-cdxj_indexer>=1.4.3
-# jinja2 dependency (https://github.com/pallets/markupsafe/issues/284)
-MarkupSafe==2.0.1
+cdxj_indexer==1.4.5

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,7 @@ def read(*names, **kwargs):
         return fh.read()
 
 
-# REPLAY_SOURCE_URL = "https://cdn.jsdelivr.net/npm/@webrecorder/wabac@2.15.5/dist/"
-REPLAY_SOURCE_URL = (
-    "https://gist.githubusercontent.com/rgaudin/"
-    "8045e7432b2184a81c9d6280be0f5724/raw/86c464e612205c0bdb5af1653f822e72e82ca2d9/"
-)
+REPLAY_SOURCE_URL = "https://cdn.jsdelivr.net/npm/@webrecorder/wabac@2.16.5/dist/"
 
 
 def download_replay(name):
@@ -77,13 +73,15 @@ setup(
         warc2zim = warc2zim.main:warc2zim
     """,
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -30,6 +30,7 @@ CMDLINES = [
     ["example-response.warc"],
     ["example-response.warc", "--progress-file", "progress.json"],
     ["example-resource.warc.gz", "--favicon", "https://example.com/some/favicon.ico"],
+    ["example-resource.warc.gz", "--favicon", "https://www.google.com/favicon.ico"],
     ["example-revisit.warc.gz"],
     [
         "example-revisit.warc.gz",
@@ -200,7 +201,7 @@ class TestWarc2Zim(object):
                 "--zim-file",
                 zim_output,
                 "-r",
-                "https://cdn.jsdelivr.net/npm/@webrecorder/wabac@2.15.5/dist/",
+                "https://cdn.jsdelivr.net/npm/@webrecorder/wabac@2.16.5/dist/",
                 "--tags",
                 "some",
                 "--tags",
@@ -246,7 +247,6 @@ class TestWarc2Zim(object):
             "Name",
             "Publisher",
             "Scraper",
-            "Source",
             "Tags",
             "Title",
         ]
@@ -440,7 +440,7 @@ class TestWarc2Zim(object):
         zim_local_sw = "zim-local-sw.zim"
 
         res = requests.get(
-            "https://cdn.jsdelivr.net/npm/@webrecorder/wabac@2.15.5/dist/sw.js"
+            "https://cdn.jsdelivr.net/npm/@webrecorder/wabac@2.16.5/dist/sw.js"
         )
 
         with open(tmp_path / "sw.js", "wt") as fh:


### PR DESCRIPTION
zimscraperlib 3.1 enforces all openZIM recommended metadata. Due to the very flexible nature of zimit, most of it consists in supporting setting those metadata as well as defining fallbacks.

Illustration is now handled differently. It uses the scraperlib fallback but also converts and resizes found favicon.

One test changed as to not expect a `Source` metadata as it is not specifying one nor a main_url.

using wabac 2.16.5

Dropping support for Python 3.6