### PR TITLE
[bugfix] improved exception handling in parse_title

### DIFF
--- a/src/warc2zim/main.py
+++ b/src/warc2zim/main.py
@@ -711,10 +711,10 @@ def get_record_mime_type(record):
 
 # ============================================================================
 def parse_title(content):
-    soup = BeautifulSoup(content, "html.parser")
     try:
+        soup = BeautifulSoup(content, "html.parser")
         return soup.title.text or ""
-    except AttributeError:
+    except Exception:
         return ""
 
 


### PR DESCRIPTION
This PR is meant to improve exception handling in parse_title.
Here is the [input file](https://transfer.sh/CfBSB4POLc/61.warc.gz) that revealed this problem.

<details>
<summary> Error output  </summary>

```
user@676948c155b1:~$ env VIRTUAL_ENV=v_warc2zim ./v_warc2zim/bin/warc2zim --verbose --lang eng --output zim/ --zim-file big.zim --name "big" warc/61.warc.gz 
[DEBUG] Confirming output is writable using /home/user/zim/tmp4ycoib1s
[DEBUG] Title: Kubernetes Community Meeting Notes - 20160218 | Kubernetes
[DEBUG] Language: eng
[DEBUG] Favicon: https://kubernetes.io/images/favicon.png
[WARNING] Some characters could not be decoded, and were replaced with REPLACEMENT CHARACTER.
[WARNING] Some characters could not be decoded, and were replaced with REPLACEMENT CHARACTER.
[WARNING] Some characters could not be decoded, and were replaced with REPLACEMENT CHARACTER.
[WARNING] Some characters could not be decoded, and were replaced with REPLACEMENT CHARACTER.
[DEBUG] Adding fuzzy redirect https://youtube.fuzzy.replayweb.page/embed/1m2FOuB6Bh0 -> https://www.youtube.com/embed/1m2FOuB6Bh0
[WARNING] Some characters could not be decoded, and were replaced with REPLACEMENT CHARACTER.
[WARNING] Some characters could not be decoded, and were replaced with REPLACEMENT CHARACTER.
[WARNING] Some characters could not be decoded, and were replaced with REPLACEMENT CHARACTER.
[WARNING] Some characters could not be decoded, and were replaced with REPLACEMENT CHARACTER.
Traceback (most recent call last):
  File "/home/user/./v_warc2zim/bin/warc2zim", line 8, in <module>
    sys.exit(warc2zim())
             ^^^^^^^^^^
  File "/home/user/v_warc2zim/lib/python3.11/site-packages/warc2zim/main.py", line 815, in warc2zim
    return warc2zim.run()
           ^^^^^^^^^^^^^^
  File "/home/user/v_warc2zim/lib/python3.11/site-packages/warc2zim/main.py", line 433, in run
    self.add_items_for_warc_record(record)
  File "/home/user/v_warc2zim/lib/python3.11/site-packages/warc2zim/main.py", line 650, in add_items_for_warc_record
    payload_item = WARCPayloadItem(record, self.head_insert, self.css_insert)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/v_warc2zim/lib/python3.11/site-packages/warc2zim/main.py", line 179, in __init__
    self.title = parse_title(self.content)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/v_warc2zim/lib/python3.11/site-packages/warc2zim/main.py", line 719, in parse_title
    soup = BeautifulSoup(content, "html.parser")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/v_warc2zim/lib/python3.11/site-packages/bs4/__init__.py", line 348, in __init__
    self._feed()
  File "/home/user/v_warc2zim/lib/python3.11/site-packages/bs4/__init__.py", line 434, in _feed
    self.builder.feed(self.markup)
  File "/home/user/v_warc2zim/lib/python3.11/site-packages/bs4/builder/_htmlparser.py", line 377, in feed
    parser.feed(markup)
  File "/usr/lib/python3.11/html/parser.py", line 110, in feed
    self.goahead(0)
  File "/usr/lib/python3.11/html/parser.py", line 178, in goahead
    k = self.parse_html_declaration(i)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/html/parser.py", line 263, in parse_html_declaration
    return self.parse_marked_section(i)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/_markupbase.py", line 144, in parse_marked_section
    sectName, j = self._scan_name( i+3, i )
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/_markupbase.py", line 390, in _scan_name
    raise AssertionError(
AssertionError: expected name token at '<![\x00�n�~�\x12܂\t2c@+2JW�'
FATAL: exception not rethrown
Aborted
```
</details>