### PR TITLE
Handles external links (without SW)

### DIFF
--- a/src/warc2zim/content_rewriting/css.py
+++ b/src/warc2zim/content_rewriting/css.py
@@ -7,12 +7,12 @@ from tinycss2 import (
 from tinycss2.serializer import serialize_url
 from tinycss2.ast import Node as TCSS2Node
 from warc2zim.url_rewriting import ArticleUrlRewriter
-from typing import Optional, Iterable, Union
+from typing import Optional, Iterable, Union, Callable
 
 
 class CssRewriter:
-    def __init__(self, css_url: str):
-        self.url_rewriter = ArticleUrlRewriter(css_url)
+    def __init__(self, url_rewriter: Callable[[str], str]):
+        self.url_rewriter = url_rewriter
 
     def rewrite(self, content: Union[str, bytes]) -> str:
         if isinstance(content, bytes):

--- a/src/warc2zim/content_rewriting/html.py
+++ b/src/warc2zim/content_rewriting/html.py
@@ -89,7 +89,11 @@ class HtmlRewriter(HTMLParser):
         self.send(f"<{tag}")
         if attrs:
             self.send(" ")
-        self.send(transform_attrs(attrs, self.url_rewriter, self.css_rewriter))
+        if tag == "a":
+            url_rewriter = lambda url: self.url_rewriter(url, False)
+        else:
+            url_rewriter = self.url_rewriter
+        self.send(transform_attrs(attrs, url_rewriter, self.css_rewriter))
 
         if auto_close:
             self.send(" />")

--- a/src/warc2zim/content_rewriting/html.py
+++ b/src/warc2zim/content_rewriting/html.py
@@ -50,10 +50,15 @@ RewritenHtml = namedtuple("RewritenHmtl", ["title", "content"])
 
 
 class HtmlRewriter(HTMLParser):
-    def __init__(self, article_url: str, pre_head_insert: str, post_head_insert: str):
+    def __init__(
+        self,
+        url_rewriter: Callable[[str], str],
+        pre_head_insert: str,
+        post_head_insert: str,
+    ):
         super().__init__()
-        self.url_rewriter = ArticleUrlRewriter(article_url)
-        self.css_rewriter = CssRewriter(article_url)
+        self.url_rewriter = url_rewriter
+        self.css_rewriter = CssRewriter(url_rewriter)
         self.title = None
         self.output = None
         # This works only for tag without children.

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -488,7 +488,11 @@ class Converter:
                 return
 
             payload_item = WARCPayloadItem(
-                normalized_url, record, self.head_template, self.css_insert
+                normalized_url,
+                record,
+                self.head_template,
+                self.css_insert,
+                self.existing_entries,
             )
 
             if len(payload_item.content) != 0:

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -132,6 +132,7 @@ class Converter:
 
         self.indexed_urls = set({})
         self.revisits = {}
+        self.existing_entries = set({})
 
         # progress file handling
         self.stats_filename = (
@@ -206,7 +207,7 @@ class Converter:
             )
             return 100
 
-        self.find_main_page_metadata()
+        self.gather_information_from_warc()
         self.title = self.title or "Untitled"
         if len(self.title) > 30:
             self.title = f"{self.title[0:29]}…"
@@ -297,16 +298,23 @@ class Converter:
 
         yield from iter_warc_records(self.inputs)
 
-    def find_main_page_metadata(self):
-        for record in self.iter_all_warc_records():
+    def gather_information_from_warc(self):
+        main_page_found = False
+        for record in iter_warc_records(self.inputs):
+            url = get_record_url(record)
+            normalized_url = normalize(url)
+
+            self.existing_entries.add(normalized_url)
+
+            if main_page_found:
+                continue
+
             if record.rec_type == "revisit":
                 continue
 
             # if no main_url, use first 'text/html' record as the main page by default
             # not guaranteed to always work
             mime = get_record_mime_type(record)
-
-            url = record.rec_headers["WARC-Target-URI"]
 
             if (
                 not self.main_url
@@ -317,9 +325,9 @@ class Converter:
                     or record.http_headers.get_statuscode() == "200"
                 )
             ):
-                self.main_url = normalize(url)
+                self.main_url = normalized_url
 
-            if urldefrag(self.main_url).url != normalize(url):
+            if urldefrag(self.main_url).url != normalized_url:
                 continue
 
             # if we get here, found record for the main page
@@ -331,7 +339,8 @@ class Converter:
                     "Main page is not an HTML Page, mime type is: {0} "
                     "- Skipping Favicon and Language detection".format(mime)
                 )
-                return
+                main_page_found = True
+                continue
 
             record.buffered_stream.seek(0)
             content = record.buffered_stream.read()
@@ -344,11 +353,12 @@ class Converter:
             logger.debug("Title: {0}".format(self.title))
             logger.debug("Language: {0}".format(self.language))
             logger.debug("Favicon: {0}".format(self.favicon_url))
-            return
+            main_page_found = True
 
-        raise KeyError(
-            f"Unable to find WARC record for main page: {self.main_url}, aborting"
-        )
+        if not main_page_found:
+            raise KeyError(
+                f"Unable to find WARC record for main page: {self.main_url}, aborting"
+            )
 
     def find_icon_and_language(self, content):
         soup = BeautifulSoup(content, "html.parser")

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -492,7 +492,7 @@ class Converter:
                 record,
                 self.head_template,
                 self.css_insert,
-                self.existing_entries,
+                self.warc_urls,
             )
 
             if len(payload_item.content) != 0:

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -132,7 +132,7 @@ class Converter:
 
         self.indexed_urls = set({})
         self.revisits = {}
-        self.existing_entries = set({})
+        self.warc_urls = set({})
 
         # progress file handling
         self.stats_filename = (
@@ -304,7 +304,7 @@ class Converter:
             url = get_record_url(record)
             normalized_url = normalize(url)
 
-            self.existing_entries.add(normalized_url)
+            self.warc_urls.add(normalized_url)
 
             if main_page_found:
                 continue

--- a/src/warc2zim/items.py
+++ b/src/warc2zim/items.py
@@ -19,6 +19,7 @@ from warcio.recordloader import ArcWarcRecord
 from warc2zim.utils import get_record_url, get_record_mime_type
 from warc2zim.url_rewriting import ArticleUrlRewriter
 from warc2zim.content_rewriting import HtmlRewriter, CssRewriter, JsRewriter
+from typing import Set
 
 # Shared logger
 logger = logging.getLogger("warc2zim.items")
@@ -30,7 +31,12 @@ class WARCPayloadItem(StaticItem):
     """
 
     def __init__(
-        self, path: str, record: ArcWarcRecord, head_template: str, css_insert: str
+        self,
+        path: str,
+        record: ArcWarcRecord,
+        head_template: str,
+        css_insert: str,
+        known_urls: Set[str],
     ):
         super().__init__()
         self.record = record
@@ -48,7 +54,7 @@ class WARCPayloadItem(StaticItem):
             return
 
         orig_url_str = get_record_url(record)
-        url_rewriter = ArticleUrlRewriter(orig_url_str, set())
+        url_rewriter = ArticleUrlRewriter(orig_url_str, known_urls)
 
         if self.mimetype.startswith("text/html"):
             orig_url = urlsplit(orig_url_str)

--- a/src/warc2zim/items.py
+++ b/src/warc2zim/items.py
@@ -62,10 +62,10 @@ class WARCPayloadItem(StaticItem):
                 orig_host=orig_url.netloc,
             )
             self.title, self.content = HtmlRewriter(
-                orig_url_str, head_insert, css_insert
+                url_rewriter, head_insert, css_insert
             ).rewrite(self.content)
         elif self.mimetype.startswith("text/css"):
-            self.content = CssRewriter(orig_url_str).rewrite(self.content)
+            self.content = CssRewriter(url_rewriter).rewrite(self.content)
         elif "javascript" in self.mimetype:
             self.content = JsRewriter(url_rewriter).rewrite(self.content.decode())
 

--- a/src/warc2zim/items.py
+++ b/src/warc2zim/items.py
@@ -48,7 +48,7 @@ class WARCPayloadItem(StaticItem):
             return
 
         orig_url_str = get_record_url(record)
-        url_rewriter = ArticleUrlRewriter(orig_url_str)
+        url_rewriter = ArticleUrlRewriter(orig_url_str, set())
 
         if self.mimetype.startswith("text/html"):
             orig_url = urlsplit(orig_url_str)

--- a/src/warc2zim/url_rewriting.py
+++ b/src/warc2zim/url_rewriting.py
@@ -136,7 +136,7 @@ def normalize(url: str | bytes) -> str:
     return path
 
 
-def remove_anchor(url: str) -> str:
+def get_without_fragment(url: str) -> str:
     parsed = urlsplit(url)
     return urlunsplit(parsed._replace(fragment=""))
 
@@ -165,7 +165,7 @@ class ArticleUrlRewriter:
 
         normalized_url = normalize(absolute_url)
 
-        if rewrite_all_url or remove_anchor(normalized_url) in self.known_urls:
+        if rewrite_all_url or get_without_fragment(normalized_url) in self.known_urls:
             return self.from_normalized(normalized_url)
         else:
             print(f"WARNING {normalized_url} ({url}) not in archive.")

--- a/src/warc2zim/url_rewriting.py
+++ b/src/warc2zim/url_rewriting.py
@@ -136,17 +136,23 @@ def normalize(url: str | bytes) -> str:
     return path
 
 
+def remove_anchor(url: str) -> str:
+    parsed = urlsplit(url)
+    return urlunsplit(parsed._replace(fragment=""))
+
+
 class ArticleUrlRewriter:
     """Rewrite urls in article."""
 
-    def __init__(self, article_url: str):
+    def __init__(self, article_url: str, known_urls: Set[str]):
         self.article_url = article_url
+        self.known_urls = known_urls
         self.base_path = f"/{urlsplit(normalize(article_url)).path}"
         if self.base_path[-1] != "/":
             # We want a directory
             self.base_path = posixpath.dirname(self.base_path)
 
-    def __call__(self, url: str) -> str:
+    def __call__(self, url: str, rewrite_all_url: bool = True) -> str:
         """Rewrite a url contained in a article.
 
         The url is "fully" rewrited to point to a normalized entry path
@@ -158,7 +164,13 @@ class ArticleUrlRewriter:
         absolute_url = urljoin(self.article_url, url)
 
         normalized_url = normalize(absolute_url)
-        return self.from_normalized(normalized_url)
+
+        if rewrite_all_url or remove_anchor(normalized_url) in self.known_urls:
+            return self.from_normalized(normalized_url)
+        else:
+            print(f"WARNING {normalized_url} ({url}) not in archive.")
+            # The url doesn't point to a known entry
+            return url
 
     def from_normalized(self, normalized_url_str: str) -> str:
         normalized_url = urlsplit(f"/{normalized_url_str}")

--- a/tests/test_css_rewriting.py
+++ b/tests/test_css_rewriting.py
@@ -1,4 +1,5 @@
 import pytest
+from warc2zim.url_rewriting import ArticleUrlRewriter
 from warc2zim.content_rewriting import CssRewriter
 from textwrap import dedent
 
@@ -18,7 +19,7 @@ def no_rewrite_content(request):
 
 def test_no_rewrite(no_rewrite_content):
     assert (
-        CssRewriter("kiwix.org").rewrite(no_rewrite_content)
+        CssRewriter(ArticleUrlRewriter("kiwix.org", set())).rewrite(no_rewrite_content)
         == no_rewrite_content.decode()
     )
 
@@ -65,4 +66,7 @@ p, input {
     }"""
     expected = dedent(expected)
 
-    assert CssRewriter("kiwix.org/article").rewrite(content) == expected
+    assert (
+        CssRewriter(ArticleUrlRewriter("kiwix.org/article", set())).rewrite(content)
+        == expected
+    )

--- a/tests/test_html_rewriting.py
+++ b/tests/test_html_rewriting.py
@@ -2,6 +2,7 @@ from textwrap import dedent
 
 import pytest
 
+from warc2zim.url_rewriting import ArticleUrlRewriter
 from warc2zim.content_rewriting import HtmlRewriter
 from .utils import TestContent
 
@@ -29,7 +30,7 @@ def no_rewrite_content(request):
 
 def test_no_rewrite(no_rewrite_content):
     assert (
-        HtmlRewriter(no_rewrite_content.article_url, "", "")
+        HtmlRewriter(ArticleUrlRewriter(no_rewrite_content.article_url, set()), "", "")
         .rewrite(no_rewrite_content.input)
         .content
         == no_rewrite_content.expected
@@ -58,7 +59,7 @@ def escaped_content(request):
 
 def test_escaped_content(escaped_content):
     transformed = (
-        HtmlRewriter(escaped_content.article_url, "", "")
+        HtmlRewriter(ArticleUrlRewriter(escaped_content.article_url, set()), "", "")
         .rewrite(escaped_content.input)
         .content
     )
@@ -144,7 +145,15 @@ def rewrite_url(request):
 
 def test_rewrite(rewrite_url):
     assert (
-        HtmlRewriter(rewrite_url.article_url, "", "").rewrite(rewrite_url.input).content
+        HtmlRewriter(
+            ArticleUrlRewriter(
+                rewrite_url.article_url, set(["exemple.com/a/long/path"])
+            ),
+            "",
+            "",
+        )
+        .rewrite(rewrite_url.input)
+        .content
         == rewrite_url.expected
     )
 
@@ -163,7 +172,9 @@ def test_extract_title():
 
 
 def test_rewrite_attributes():
-    rewriter = HtmlRewriter("kiwix.org/", "", "")
+    rewriter = HtmlRewriter(
+        ArticleUrlRewriter("kiwix.org/", set(["kiwix.org/foo"])), "", ""
+    )
 
     assert (
         rewriter.rewrite("<a href='https://kiwix.org/foo'>A link</a>").content
@@ -185,7 +196,7 @@ def test_rewrite_attributes():
 
 def test_rewrite_css():
     output = (
-        HtmlRewriter("", "", "")
+        HtmlRewriter(ArticleUrlRewriter("", set()), "", "")
         .rewrite(
             "<style>p { /* A comment with a http://link.org/ */ background: url('some/image.png') ; }</style>",
         )
@@ -207,15 +218,16 @@ def test_head_insert():
 
     content = dedent(content)
 
-    assert HtmlRewriter("foo", "", "").rewrite(content).content == content
+    url_rewriter = ArticleUrlRewriter("foo", set())
+    assert HtmlRewriter(url_rewriter, "", "").rewrite(content).content == content
 
-    assert HtmlRewriter("foo", "PRE_HEAD_INSERT", "").rewrite(
+    assert HtmlRewriter(url_rewriter, "PRE_HEAD_INSERT", "").rewrite(
         content
     ).content == content.replace("<head>", "<head>PRE_HEAD_INSERT")
-    assert HtmlRewriter("foo", "", "POST_HEAD_INSERT").rewrite(
+    assert HtmlRewriter(url_rewriter, "", "POST_HEAD_INSERT").rewrite(
         content
     ).content == content.replace("</head>", "POST_HEAD_INSERT</head>")
-    assert HtmlRewriter("foo", "PRE_HEAD_INSERT", "POST_HEAD_INSERT").rewrite(
+    assert HtmlRewriter(url_rewriter, "PRE_HEAD_INSERT", "POST_HEAD_INSERT").rewrite(
         content
     ).content == content.replace("<head>", "<head>PRE_HEAD_INSERT").replace(
         "</head>", "POST_HEAD_INSERT</head>"

--- a/tests/test_html_rewriting.py
+++ b/tests/test_html_rewriting.py
@@ -146,9 +146,7 @@ def rewrite_url(request):
 def test_rewrite(rewrite_url):
     assert (
         HtmlRewriter(
-            ArticleUrlRewriter(
-                rewrite_url.article_url, set(["exemple.com/a/long/path"])
-            ),
+            ArticleUrlRewriter(rewrite_url.article_url, {"exemple.com/a/long/path"}),
             "",
             "",
         )
@@ -172,9 +170,7 @@ def test_extract_title():
 
 
 def test_rewrite_attributes():
-    rewriter = HtmlRewriter(
-        ArticleUrlRewriter("kiwix.org/", set(["kiwix.org/foo"])), "", ""
-    )
+    rewriter = HtmlRewriter(ArticleUrlRewriter("kiwix.org/", {"kiwix.org/foo"}), "", "")
 
     assert (
         rewriter.rewrite("<a href='https://kiwix.org/foo'>A link</a>").content

--- a/tests/test_js_rewriting.py
+++ b/tests/test_js_rewriting.py
@@ -199,7 +199,7 @@ def rewrite_import_content(request):
 
 
 def test_import_rewrite(rewrite_import_content):
-    url_rewriter = ArticleUrlRewriter(rewrite_import_content.article_url)
+    url_rewriter = ArticleUrlRewriter(rewrite_import_content.article_url, set())
     assert (
         JsRewriter(url_rewriter).rewrite(rewrite_import_content.input)
         == rewrite_import_content.expected

--- a/tests/test_url_rewriting.py
+++ b/tests/test_url_rewriting.py
@@ -12,7 +12,7 @@ from urllib.parse import urljoin
     ]
 )
 def rewriter(request):
-    yield ArticleUrlRewriter(request.param)
+    yield ArticleUrlRewriter(request.param, set(["kiwix.org/bar/foo"]))
 
 
 def test_relative_url(rewriter):
@@ -76,3 +76,18 @@ def test_absolute_url(rewriter):
 def test_no_rewrite_blob_data(rewriter):
     for url in ["data:0548datacontent", "blob:exemple.com/url"]:
         assert rewriter(url) == url
+
+
+def test_no_rewrite_external_link(rewriter):
+    for rewrite_all_url in [True, False]:
+        # We always rewrite "internal" urls
+        assert "kiwix.org" not in rewriter("https://kiwix.org/bar/foo")
+
+    # External urls are only rewriten if 'rewrite_all_url' is True
+    assert "kiwix.org" not in rewriter(
+        "https://kiwix.org/external/link", rewrite_all_url=True
+    )
+    assert (
+        rewriter("https://kiwix.org/external/link", rewrite_all_url=False)
+        == "https://kiwix.org/external/link"
+    )

--- a/tests/test_url_rewriting.py
+++ b/tests/test_url_rewriting.py
@@ -12,7 +12,7 @@ from urllib.parse import urljoin
     ]
 )
 def rewriter(request):
-    yield ArticleUrlRewriter(request.param, set(["kiwix.org/bar/foo"]))
+    yield ArticleUrlRewriter(request.param, {"kiwix.org/bar/foo"})
 
 
 def test_relative_url(rewriter):


### PR DESCRIPTION
Fixes #137 

With this PR we don't rewrite html (`a href`) link when the url is not in the warc archive.

Other links are always rewritten to avoid zim file silently phoning home.
