### PR TITLE
Do not crash when html is malformed and doesn't contains a actual sytle.

### DIFF
--- a/src/warc2zim/content_rewriting/html.py
+++ b/src/warc2zim/content_rewriting/html.py
@@ -27,7 +27,7 @@ def process_attr(
             new_value = " ".join([new_url, *other])
             new_value_list.append(new_value)
         return (attr[0], ", ".join(new_value_list))
-    if attr[0] == "style":
+    if attr[0] == "style" and attr[1]:
         return (attr[0], css_rewriter.rewrite_inline(attr[1]))
     return attr
 

--- a/tests/test_html_rewriting.py
+++ b/tests/test_html_rewriting.py
@@ -19,6 +19,7 @@ from .utils import TestContent
         TestContent(
             '<p style="background: url(some/image.png);">A url (relative) in a inline style</p>'
         ),
+        TestContent("<p style></p>"),
         TestContent(
             '<style>p { /* A comment with a http://link.org/ */ background: url("some/image.png") ; }</style>'
         ),


### PR DESCRIPTION
Fix openzim/zimit#265