### PR TITLE
Introduce generic Rewriter dispatching between specific rewriters.

### DIFF
--- a/src/warc2zim/content_rewriting/ds.py
+++ b/src/warc2zim/content_rewriting/ds.py
@@ -17,6 +17,7 @@ from warc2zim.content_rewriting.js import (
     add_prefix,
     m2str,
 )
+from warc2zim.content_rewriting.rx_replacer import add_suffix, replace_all
 
 
 @dataclass
@@ -29,22 +30,6 @@ def add_around(prefix: str, suffix: str) -> TransformationAction:
     @m2str
     def f(x) -> str:
         return prefix + x + suffix
-
-    return f
-
-
-def replace_all(text: str) -> TransformationAction:
-    @m2str
-    def f(_x) -> str:
-        return text
-
-    return f
-
-
-def add_suffix_all(suffix) -> TransformationAction:
-    @m2str
-    def f(x) -> str:
-        return x + suffix
 
     return f
 
@@ -196,19 +181,19 @@ RULES = [
             ),
             (
                 re.compile(r"yt\.setConfig.*PLAYER_CONFIG.*args\":\s*{"),
-                add_suffix_all(' "dash": "0", dashmpd: "", '),
+                add_suffix(' "dash": "0", dashmpd: "", '),
             ),
             (
                 re.compile(r"(?:\"player\":|ytplayer\.config).*\"args\":\s*{"),
-                add_suffix_all('"dash":"0","dashmpd":"",'),
+                add_suffix('"dash":"0","dashmpd":"",'),
             ),
             (
                 re.compile(r"yt\.setConfig.*PLAYER_VARS.*?{"),
-                add_suffix_all('"dash":"0","dashmpd":"",'),
+                add_suffix('"dash":"0","dashmpd":"",'),
             ),
             (
                 re.compile(r"ytplayer.config={args:\s*{"),
-                add_suffix_all('"dash":"0","dashmpd":"",'),
+                add_suffix('"dash":"0","dashmpd":"",'),
             ),
             (re.compile(r"\"0\"\s*?==\s*?\w+\.dash&&", re.M), replace_all("1&&")),
         ],

--- a/src/warc2zim/content_rewriting/ds.py
+++ b/src/warc2zim/content_rewriting/ds.py
@@ -17,21 +17,13 @@ from warc2zim.content_rewriting.js import (
     add_prefix,
     m2str,
 )
-from warc2zim.content_rewriting.rx_replacer import add_suffix, replace_all
+from warc2zim.content_rewriting.rx_replacer import add_around, add_suffix, replace_all
 
 
 @dataclass
 class SpecificRules:
     contains: list[str]
     rx_rules: list[TransformationRule]
-
-
-def add_around(prefix: str, suffix: str) -> TransformationAction:
-    @m2str
-    def f(x) -> str:
-        return prefix + x + suffix
-
-    return f
 
 
 MAX_BITRATE = 5000000

--- a/src/warc2zim/content_rewriting/ds.py
+++ b/src/warc2zim/content_rewriting/ds.py
@@ -1,0 +1,292 @@
+## This file is almost a plain translation from a JavaScript file.
+## https://github.com/webrecorder/wabac.js/blob/219830cea0a732bdd72ce100fcfd2f3a1c9c3607/src/rewrite/dsruleset.js
+## Partly translated by a human, partly by ChatGPT.
+
+## The ruleset should be kept in sync with the original ones, but there is no easy
+## automatic process for that at the moment.
+
+
+import json
+import re
+from dataclasses import dataclass
+
+from warc2zim.content_rewriting.js import (
+    JsRewriter,
+    TransformationAction,
+    TransformationRule,
+    add_prefix,
+    m2str,
+)
+
+
+@dataclass
+class SpecificRules:
+    contains: list[str]
+    rx_rules: list[TransformationRule]
+
+
+def add_around(prefix: str, suffix: str) -> TransformationAction:
+    @m2str
+    def f(x) -> str:
+        return prefix + x + suffix
+
+    return f
+
+
+def replace_all(text: str) -> TransformationAction:
+    @m2str
+    def f(_x) -> str:
+        return text
+
+    return f
+
+
+def add_suffix_all(suffix) -> TransformationAction:
+    @m2str
+    def f(x) -> str:
+        return x + suffix
+
+    return f
+
+
+MAX_BITRATE = 5000000
+
+
+def set_max_bitrate(_opts: dict) -> int:
+    max_bitrate = MAX_BITRATE
+
+    # Extra opts is used in wabac, but we never set it ourself here.
+    # Let's comment it until we figure out
+    # extra_opts = opts["response"]["extraOpts"] if "response" in opts else None
+    # if extra_opts["save"]:
+    #    opts["save"]["maxBitrate"] = maxBitrate
+    # elif extra_opts and extra_opts["maxBitrate"]:
+    #    max_bitrate = extra_opts["maxBitrate"]
+
+    return max_bitrate
+
+
+def rule_rewrite_twitter_video(prefix: str) -> TransformationAction:
+    def rewrite(m_object: re.Match, opts: dict) -> str:
+        string = m_object[0]
+        if not opts:
+            return string
+
+        orig_string = string
+
+        try:
+            w_x_h = re.compile(r"([\d]+)x([\d]+)")
+
+            max_bitrate = set_max_bitrate(opts)
+
+            string = string[len(prefix) :]
+
+            data = json.loads(string)
+
+            best_variant = None
+            best_bitrate = 0
+
+            for variant in data["variants"]:
+                if (
+                    variant.get("content_type")
+                    and variant["content_type"] != "video/mp4"
+                ) or (variant.get("type") and variant["type"] != "video/mp4"):
+                    continue
+
+                if (
+                    variant.get("bitrate")
+                    and variant["bitrate"] > best_bitrate
+                    and variant["bitrate"] <= max_bitrate
+                ):
+                    best_variant = variant
+                    best_bitrate = variant["bitrate"]
+                elif variant.get("src"):
+                    matched = w_x_h.search(variant["src"])
+                    if matched:
+                        bitrate = int(matched.group(1)) * int(matched.group(2))
+                        if bitrate > best_bitrate:
+                            best_bitrate = bitrate
+                            best_variant = variant
+
+            if best_variant:
+                data["variants"] = [best_variant]
+
+            return prefix + json.dumps(data)
+
+        except Exception:
+            return orig_string
+
+    return rewrite
+
+
+@m2str
+def rule_rewrite_vimeo_config(string: str) -> str:
+    try:
+        config = json.loads(string)
+    except Exception:
+        return string
+
+    if config and config.get("request") and config["request"].get("files"):
+        files = config["request"]["files"]
+        if isinstance(files.get("progressive"), list) and len(files["progressive"]) > 0:
+            if "dash" in files:
+                files["__dash"] = files["dash"]
+                del files["dash"]
+            if "hls" in files:
+                files["__hls"] = files["hls"]
+                del files["hls"]
+
+            return json.dumps(config)
+
+    return re.sub("query_string_ranges=1", "query_string_ranges=0", string)
+
+
+def rule_rewrite_vimeo_dash_manifest(m_object: re.Match, opts: dict | None) -> str:
+    string = m_object[0]
+    if not opts:
+        return string
+
+    vimeo_manifest = None
+
+    max_bitrate = set_max_bitrate(opts)
+
+    try:
+        vimeo_manifest = json.loads(string)
+    except Exception:
+        return string
+
+    def filter_by_bitrate(array, max_bitrate, mime):
+        if not array:
+            return None
+
+        best_variant = 0
+        best_bitrate = None
+
+        for variant in array:
+            if (
+                variant.get("mime_type") == mime
+                and variant.get("bitrate") > best_bitrate
+                and variant.get("bitrate") <= max_bitrate
+            ):
+                best_bitrate = variant.get("bitrate")
+                best_variant = variant
+
+        return [best_variant] if best_variant else array
+
+    vimeo_manifest["video"] = filter_by_bitrate(
+        vimeo_manifest.get("video"), max_bitrate, "video/mp4"
+    )
+    vimeo_manifest["audio"] = filter_by_bitrate(
+        vimeo_manifest.get("audio"), max_bitrate, "audio/mp4"
+    )
+
+    return json.dumps(vimeo_manifest)
+
+
+RULES = [
+    SpecificRules(
+        ["youtube.com", "youtube-nocookie.com"],
+        [
+            (
+                re.compile(r"ytplayer.load\(\);"),
+                add_prefix(
+                    'ytplayer.config.args.dash = "0";'
+                    ' ytplayer.config.args.dashmpd = ""; '
+                ),
+            ),
+            (
+                re.compile(r"yt\.setConfig.*PLAYER_CONFIG.*args\":\s*{"),
+                add_suffix_all(' "dash": "0", dashmpd: "", '),
+            ),
+            (
+                re.compile(r"(?:\"player\":|ytplayer\.config).*\"args\":\s*{"),
+                add_suffix_all('"dash":"0","dashmpd":"",'),
+            ),
+            (
+                re.compile(r"yt\.setConfig.*PLAYER_VARS.*?{"),
+                add_suffix_all('"dash":"0","dashmpd":"",'),
+            ),
+            (
+                re.compile(r"ytplayer.config={args:\s*{"),
+                add_suffix_all('"dash":"0","dashmpd":"",'),
+            ),
+            (re.compile(r"\"0\"\s*?==\s*?\w+\.dash&&", re.M), replace_all("1&&")),
+        ],
+    ),
+    SpecificRules(
+        ["player.vimeo.com/video/"],
+        [(re.compile(r"^\{.+\}$"), rule_rewrite_vimeo_config)],
+    ),
+    SpecificRules(
+        ["master.json?query_string_ranges=0", "master.json?base64"],
+        [(re.compile(r"r^\{.+\}$"), rule_rewrite_vimeo_dash_manifest)],
+    ),
+    SpecificRules(
+        ["facebook.com/"],
+        [
+            (re.compile(r"\"dash_"), replace_all('"__nodash__')),
+            (re.compile(r"_dash\""), replace_all('__nodash__"')),
+            (re.compile(r"_dash_"), replace_all("__nodash__")),
+            (
+                re.compile(r"\"debugNoBatching\s?\":(?:false|0)"),
+                replace_all('"debugNoBatching":true'),
+            ),
+        ],
+    ),
+    SpecificRules(
+        ["instagram.com/"],
+        [
+            (
+                re.compile(r"\"is_dash_eligible\":(?:true|1)"),
+                replace_all('"is_dash_eligible":false'),
+            ),
+            (
+                re.compile(r"\"debugNoBatching\s?\":(?:false|0)"),
+                replace_all('"debugNoBatching":true'),
+            ),
+        ],
+    ),
+    SpecificRules(
+        ["api.twitter.com/2/", "twitter.com/i/api/2/", "twitter.com/i/api/graphql/"],
+        [
+            (
+                re.compile(r"\"video_info\":.*?}]}"),
+                rule_rewrite_twitter_video('"video_info":'),
+            )
+        ],
+    ),
+    SpecificRules(
+        ["cdn.syndication.twimg.com/tweet-result"],
+        [
+            (
+                re.compile(r"\"video\":.*?viewCount\":\d+}"),
+                rule_rewrite_twitter_video('"video":'),
+            )
+        ],
+    ),
+    SpecificRules(
+        ["/vqlweb.js"],
+        [
+            (
+                re.compile(
+                    r"b\w+\.updatePortSize\(\);this\.updateApplicationSize\(\)(?![*])",
+                    re.I | re.M,
+                ),
+                add_around("/*", "*/"),
+            )
+        ],
+    ),
+]
+
+
+def build_domain_specific_rewriter(path: str, url_rewriter):
+    """
+    This build a JsRewriter with extra rules depending of the path.
+    """
+
+    for rule in RULES:
+        for contain in rule.contains:
+            if contain in path:
+                return JsRewriter(url_rewriter, rule.rx_rules)
+
+    return JsRewriter(url_rewriter)

--- a/src/warc2zim/content_rewriting/generic.py
+++ b/src/warc2zim/content_rewriting/generic.py
@@ -1,0 +1,78 @@
+from urllib.parse import urlsplit
+
+from jinja2.environment import Template
+from warcio.recordloader import ArcWarcRecord
+
+from warc2zim.content_rewriting.css import CssRewriter
+from warc2zim.content_rewriting.html import HtmlRewriter
+from warc2zim.content_rewriting.js import JsRewriter
+from warc2zim.url_rewriting import ArticleUrlRewriter
+from warc2zim.utils import get_record_content, get_record_mime_type, get_record_url
+
+
+class Rewriter:
+    def __init__(
+        self,
+        path: str,
+        record: ArcWarcRecord,
+        known_urls: set[str],
+    ):
+        self.content = get_record_content(record)
+
+        mimetype = get_record_mime_type(record)
+
+        self.path = path
+        self.orig_url_str = get_record_url(record)
+        self.url_rewriter = ArticleUrlRewriter(self.orig_url_str, known_urls)
+
+        self.rewrite_mode = self.get_rewrite_mode(record, mimetype)
+
+    def rewrite(
+        self, head_template: Template, css_insert: str | None
+    ) -> tuple[str, str | bytes]:
+        if self.rewrite_mode == "html":
+            return self.rewrite_html(head_template, css_insert)
+
+        if self.rewrite_mode == "css":
+            return self.rewrite_css()
+
+        if self.rewrite_mode == "javascript":
+            return self.rewrite_js()
+
+        return ("", self.content)
+
+    def get_rewrite_mode(self, record, mimetype):
+        if getattr(record, "method", "GET") == "POST":
+            return None
+        if mimetype == "text/html":
+            # TODO : Handle header "Accept" == "application/json"
+            return "html"
+
+        if mimetype == "text/css":
+            return "css"
+
+        if "javascript" in mimetype:
+            return "javascript"
+
+        return None
+
+    def rewrite_html(self, head_template: Template, css_insert: str | None):
+        orig_url = urlsplit(self.orig_url_str)
+
+        rel_static_prefix = self.url_rewriter.from_normalized("_zim_static/")
+        head_insert = head_template.render(
+            path=self.path,
+            static_prefix=rel_static_prefix,
+            orig_url=self.orig_url_str,
+            orig_scheme=orig_url.scheme,
+            orig_host=orig_url.netloc,
+        )
+        return HtmlRewriter(self.url_rewriter, head_insert, css_insert).rewrite(
+            self.content
+        )
+
+    def rewrite_css(self):
+        return ("", CssRewriter(self.url_rewriter).rewrite(self.content))
+
+    def rewrite_js(self):
+        return ("", JsRewriter(self.url_rewriter).rewrite(self.content.decode()))

--- a/src/warc2zim/content_rewriting/js.py
+++ b/src/warc2zim/content_rewriting/js.py
@@ -55,7 +55,7 @@ GLOBALS_RX = re.compile(
 this_rw = "_____WB$wombat$check$this$function_____(this)"
 
 
-def add_suffix(suffix) -> TransformationAction:
+def add_suffix_non_prop(suffix) -> TransformationAction:
     """
     Create a rewrite_function which add a `suffix` to the match str.
     The suffix is added only if the match is not preceded by `.` or `$`.
@@ -151,7 +151,7 @@ def create_js_rules() -> list[TransformationRule]:
         # rewriting `location = ` to custom expression `(...).href =` assignement
         (
             re.compile(r"[^$.]?\s?\blocation\b\s*[=]\s*(?![\s\d=])"),
-            add_suffix(check_loc),
+            add_suffix_non_prop(check_loc),
         ),
         # rewriting `return this`
         (re.compile(r"\breturn\s+this\b\s*(?![\s\w.$])"), replace_this()),

--- a/src/warc2zim/content_rewriting/js.py
+++ b/src/warc2zim/content_rewriting/js.py
@@ -1,11 +1,17 @@
 import re
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from typing import Any
 
 from warc2zim.content_rewriting import UrlRewriterProto
-
-TransformationAction = Callable[[re.Match, dict], str]
-TransformationRule = tuple[re.Pattern, TransformationAction]
+from warc2zim.content_rewriting.rx_replacer import (
+    RxRewriter,
+    TransformationAction,
+    TransformationRule,
+    add_prefix,
+    m2str,
+    replace,
+    replace_prefix_from,
+)
 
 # Regex used to check if we ar import or exporting things in the string
 # ie : If we are a module
@@ -49,46 +55,6 @@ GLOBALS_RX = re.compile(
 this_rw = "_____WB$wombat$check$this$function_____(this)"
 
 
-def m2str(function) -> TransformationAction:
-    """
-    Call a rewrite_function with a string instead of a match object.
-    A lot of rewrite function don't need the match object as they are working
-    directly on text. This decorator can be used on rewrite_function taking a str.
-    """
-
-    def wrapper(m_object: re.Match, _opts: dict) -> str:
-        return function(m_object[0])
-
-    return wrapper
-
-
-def add_prefix(prefix: str) -> TransformationAction:
-    """
-    Create a rewrite_function which add the `prefix` to the matching str.
-    """
-
-    @m2str
-    def f(x):
-        return prefix + x
-
-    return f
-
-
-def replace_prefix_from(prefix: str, match: str) -> TransformationAction:
-    """
-    Returns a function which replaces everything before `match` with `prefix`.
-    """
-
-    @m2str
-    def f(x) -> str:
-        match_index = x.index(match)
-        if match_index == 0:
-            return prefix
-        return x[:match_index] + prefix
-
-    return f
-
-
 def add_suffix(suffix) -> TransformationAction:
     """
     Create a rewrite_function which add a `suffix` to the match str.
@@ -108,24 +74,7 @@ def replace_this() -> TransformationAction:
     """
     Create a rewrite_function replacing "this" by `this_rw` in the matching str.
     """
-
-    @m2str
-    def f(x):
-        return x.replace("this", this_rw)
-
-    return f
-
-
-def replace(src, target) -> TransformationAction:
-    """
-    Create a rewrite_function replacing `src` by `target` in the matching str.
-    """
-
-    @m2str
-    def f(x):
-        return x.replace(src, target)
-
-    return f
+    return replace("this", this_rw)
 
 
 def replace_this_non_prop() -> TransformationAction:
@@ -238,18 +187,9 @@ def create_js_rules() -> list[TransformationRule]:
 REWRITE_JS_RULES = create_js_rules()
 
 
-class JsRewriter:
+class JsRewriter(RxRewriter):
     """
     JsRewriter is in charge of rewriting the js code stored in our zim file.
-
-    The main "input" is a list of rules, each rule being a tuple (regex,
-    rewriting_function). We want to apply each rule to the content. But doing it blindly
-    is counter-productive. It would means that we have to do N replacements (N == number
-    of rules).
-    To avoid that, we create one unique regex (`compiled_rule`) equivalent to
-    `(regex0|regex1|regex2|...)` and we do only one replacement with this regex.
-    When we have a match, we do N regex search to know which rules is corresponding
-    and we apply the associated rewriting_function.
     """
 
     def __init__(
@@ -257,6 +197,7 @@ class JsRewriter:
         url_rewriter: UrlRewriterProto,
         extra_rules: Iterable[TransformationRule] | None = None,
     ):
+        super().__init__(None)
         self.extra_rules = extra_rules or []
         self.first_buff = self._init_local_declaration(GLOBAL_OVERRIDES)
         self.last_buff = "\n}"
@@ -317,9 +258,9 @@ class JsRewriter:
 
         rules += self.extra_rules
 
-        compiled_rules = self._compile_rules(rules)
+        self._compile_rules(rules)
 
-        new_text = self.rewrite_content(text, compiled_rules, rules, opts)
+        new_text = self.rewrite_content(text, opts)
 
         if opts["isModule"]:
             return self._get_module_decl(GLOBAL_OVERRIDES) + new_text
@@ -346,34 +287,3 @@ class JsRewriter:
             return func
 
         return (IMPORT_MATCH_RX, rewrite_import())
-
-    def _compile_rules(self, rules: Iterable[TransformationRule]) -> re.Pattern:
-        """
-        Compile all the regex of the rules into only one `compiled_rules` pattern
-        """
-        rx_buff = "|".join(f"({rule[0].pattern})" for rule in rules)
-        return re.compile(f"(?:{rx_buff})", re.M)
-
-    def rewrite_content(
-        self,
-        text: str,
-        compiled_rules: re.Pattern,
-        rules: list[TransformationRule],
-        opts: dict[str, Any],
-    ) -> str:
-        """
-        Apply the unique `compiled_rules` pattern and replace the content.
-        """
-
-        def replace(m_object):
-            """
-            This method search for the specific rule which have matched and apply it.
-            """
-            for i, rule in enumerate(rules, 1):
-                if not m_object.group(i):
-                    # THis is not the ith rules which match
-                    continue
-                result = rule[1](m_object, opts)
-                return result
-
-        return compiled_rules.sub(replace, text)

--- a/src/warc2zim/content_rewriting/rx_replacer.py
+++ b/src/warc2zim/content_rewriting/rx_replacer.py
@@ -19,16 +19,24 @@ def m2str(function) -> TransformationAction:
     return wrapper
 
 
+def add_around(prefix: str, suffix: str) -> TransformationAction:
+    """
+    Create a rewrite_function which add a `prefix` and a `suffix` around the match.
+    """
+
+    @m2str
+    def f(x):
+        return prefix + x + suffix
+
+    return f
+
+
 def add_prefix(prefix: str) -> TransformationAction:
     """
     Create a rewrite_function which add the `prefix` to the matching str.
     """
 
-    @m2str
-    def f(x):
-        return prefix + x
-
-    return f
+    return add_around(prefix, "")
 
 
 def add_suffix(suffix: str) -> TransformationAction:
@@ -36,11 +44,7 @@ def add_suffix(suffix: str) -> TransformationAction:
     Create a rewrite_function which add the `suffix` to the matching str.
     """
 
-    @m2str
-    def f(x):
-        return x + suffix
-
-    return f
+    return add_around("", suffix)
 
 
 def replace_prefix_from(prefix: str, match: str) -> TransformationAction:

--- a/src/warc2zim/content_rewriting/rx_replacer.py
+++ b/src/warc2zim/content_rewriting/rx_replacer.py
@@ -1,0 +1,113 @@
+import re
+from collections.abc import Callable, Iterable
+from typing import Any
+
+TransformationAction = Callable[[re.Match, dict], str]
+TransformationRule = tuple[re.Pattern, TransformationAction]
+
+
+def m2str(function) -> TransformationAction:
+    """
+    Call a rewrite_function with a string instead of a match object.
+    A lot of rewrite function don't need the match object as they are working
+    directly on text. This decorator can be used on rewrite_function taking a str.
+    """
+
+    def wrapper(m_object: re.Match, _opts: dict) -> str:
+        return function(m_object[0])
+
+    return wrapper
+
+
+def add_prefix(prefix: str) -> TransformationAction:
+    """
+    Create a rewrite_function which add the `prefix` to the matching str.
+    """
+
+    @m2str
+    def f(x):
+        return prefix + x
+
+    return f
+
+
+def replace_prefix_from(prefix: str, match: str) -> TransformationAction:
+    """
+    Returns a function which replaces everything before `match` with `prefix`.
+    """
+
+    @m2str
+    def f(x) -> str:
+        match_index = x.index(match)
+        if match_index == 0:
+            return prefix
+        return x[:match_index] + prefix
+
+    return f
+
+
+def replace(src, target) -> TransformationAction:
+    """
+    Create a rewrite_function replacing `src` by `target` in the matching str.
+    """
+
+    @m2str
+    def f(x):
+        return x.replace(src, target)
+
+    return f
+
+
+class RxRewriter:
+    """
+    RxRewriter is a generic rewriter base on regex.
+
+    The main "input" is a list of rules, each rule being a tuple (regex,
+    rewriting_function). We want to apply each rule to the content. But doing it blindly
+    is counter-productive. It would means that we have to do N replacements (N == number
+    of rules).
+    To avoid that, we create one unique regex (`compiled_rule`) equivalent to
+    `(regex0|regex1|regex2|...)` and we do only one replacement with this regex.
+    When we have a match, we do N regex search to know which rules is corresponding
+    and we apply the associated rewriting_function.
+    """
+
+    def __init__(
+        self,
+        rules: Iterable[TransformationRule] | None = None,
+    ):
+        self.rules = rules or []
+        self.compiled_rule: re.Pattern | None = None
+        if self.rules:
+            self._compile_rules(self.rules)
+
+    def _compile_rules(self, rules: Iterable[TransformationRule]):
+        """
+        Compile all the regex of the rules into only one `compiled_rules` pattern
+        """
+        self.rules = rules
+        rx_buff = "|".join(f"({rule[0].pattern})" for rule in rules)
+        self.compiled_rule = re.compile(f"(?:{rx_buff})", re.M)
+
+    def rewrite_content(
+        self,
+        text: str,
+        opts: dict[str, Any],
+    ) -> str:
+        """
+        Apply the unique `compiled_rules` pattern and replace the content.
+        """
+
+        def replace(m_object):
+            """
+            This method search for the specific rule which have matched and apply it.
+            """
+            for i, rule in enumerate(self.rules, 1):
+                if not m_object.group(i):
+                    # THis is not the ith rules which match
+                    continue
+                result = rule[1](m_object, opts)
+                return result
+
+        assert self.compiled_rule is not None  # noqa
+        return self.compiled_rule.sub(replace, text)

--- a/src/warc2zim/content_rewriting/rx_replacer.py
+++ b/src/warc2zim/content_rewriting/rx_replacer.py
@@ -31,6 +31,18 @@ def add_prefix(prefix: str) -> TransformationAction:
     return f
 
 
+def add_suffix(suffix: str) -> TransformationAction:
+    """
+    Create a rewrite_function which add the `suffix` to the matching str.
+    """
+
+    @m2str
+    def f(x):
+        return x + suffix
+
+    return f
+
+
 def replace_prefix_from(prefix: str, match: str) -> TransformationAction:
     """
     Returns a function which replaces everything before `match` with `prefix`.
@@ -54,6 +66,18 @@ def replace(src, target) -> TransformationAction:
     @m2str
     def f(x):
         return x.replace(src, target)
+
+    return f
+
+
+def replace_all(text: str) -> TransformationAction:
+    """
+    Create a rewrite_function which replace the whole match with text.
+    """
+
+    @m2str
+    def f(_x):
+        return text
 
     return f
 


### PR DESCRIPTION
Some js coming from specific website need to be patched to work "offline".

This patching is made using a set of specific regex to "activate" depending of path.

Sadly, there is no test because there is none in wabac.js (the source of the rules set) and
I don't know want/how to test.

We probably have more to import from wabac.js, but this PR is a fix to #149 