### PR TITLE
Allow to specify a scraper suffix for the ZIM scraper metadata at the CLI

### DIFF
--- a/src/warc2zim/__about__.py
+++ b/src/warc2zim/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-dev0"
+__version__ = "2.0.0-dev1"

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -142,6 +142,8 @@ class Converter:
 
         self.written_records = self.total_records = 0
 
+        self.scraper_suffix = args.scraper_suffix
+
     def init_env(self):
         # autoescape=False to allow injecting html entities from translated text
         env = Environment(
@@ -240,7 +242,7 @@ class Converter:
             Illustration_48x48_at_1=self.illustration,
             Tags=";".join(self.tags),
             Source=self.source,
-            Scraper=f"warc2zim {get_version()}",
+            Scraper=f"warc2zim {get_version()}{self.scraper_suffix}",
         ).start()
 
         for filename in importlib.resources.files("warc2zim.statics").iterdir():

--- a/src/warc2zim/main.py
+++ b/src/warc2zim/main.py
@@ -79,6 +79,12 @@ def main(raw_args=None):
         default="",
     )
 
+    parser.add_argument(
+        "--scraper-suffix",
+        help="Additional string to append as a suffix to ZIM Scraper metadata, in "
+        "addition to regular warc2zim value",
+    )
+
     args = parser.parse_args(args=raw_args)
     converter = Converter(args)
     return converter.run()


### PR DESCRIPTION
Fix #156 

Nota: also updates the version to `dev1` as agreed in issue.