### PR TITLE
Enhance wording about return code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Adopted Python bootstrap conventions (#152)
+- Change wording in logs about the return code 100 (which is not an error code)
 
 ## [1.5.4] - 2023-09-18
 

--- a/src/warc2zim/__about__.py
+++ b/src/warc2zim/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-dev1"
+__version__ = "2.0.0-dev2"

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -195,7 +195,7 @@ class Converter:
     def run(self):
         if not self.inputs:
             logger.info(
-                "Arguments valid, no inputs to process. Exiting with error code 100"
+                "Arguments valid, no inputs to process. Exiting with return code 100"
             )
             return 100
 

--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -465,7 +465,7 @@ class TestWarc2Zim:
         ):
             main(["--name", "test", "--output", "/no-such-dir"])
 
-        # success, special error code for no output files
+        # success, special return code for no output files
         assert main(["--name", "test", "--output", "./"]) == 100
 
     def test_custom_css(self, tmp_path):


### PR DESCRIPTION
Logs were speaking about `error code 100`, which indicates that args are OK for warc2zim.

I changed this to `return code 100` since it is the proper term and the wrong term was frequently misleading the content team into believing there was an error.