### PR TITLE
String leading and trailing space from url.

### DIFF
--- a/src/warc2zim/url_rewriting.py
+++ b/src/warc2zim/url_rewriting.py
@@ -170,6 +170,8 @@ class ArticleUrlRewriter:
         The url is "fully" rewrited to point to a normalized entry path
         """
 
+        url = url.strip()
+
         if url.startswith("data:") or url.startswith("blob:"):
             return url
 

--- a/tests/test_url_rewriting.py
+++ b/tests/test_url_rewriting.py
@@ -36,12 +36,13 @@ def test_relative_url(rewriter):
 
 def test_absolute_path_url(rewriter):
     for url in ["/foo", "/foo/bar"]:
-        rewriten = rewriter(url)
-        # Must produce a relative link.
-        assert not rewriten.startswith("/")
-        # Relative link must be resolved to a absolute url in the same domain than
-        # article_url.
-        assert urljoin(rewriter.article_url, rewriten) == "https://kiwix.org" + url
+        for input_url in [url, f" {url}", f"{url} ", f" {url} "]:
+            rewriten = rewriter(input_url)
+            # Must produce a relative link.
+            assert not rewriten.startswith("/")
+            # Relative link must be resolved to a absolute url in the same domain than
+            # article_url.
+            assert urljoin(rewriter.article_url, rewriten) == "https://kiwix.org" + url
 
 
 def test_absolute_scheme_url(rewriter):


### PR DESCRIPTION
Fix #167

Spec is explicit about that, we can have space around url: https://www.w3.org/TR/2014/REC-html5-20141028/infrastructure.html#valid-url-potentially-surrounded-by-spaces