### PR TITLE
Fix Vimeo video

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -11,6 +11,7 @@ WOMBAT_SOURCE_URL = "https://cdn.jsdelivr.net/npm/@webrecorder/wombat@3.7.0/dist
 class GetJsDepsHook(BuildHookInterface):
     def initialize(self, version, build_data):
         self.download_wombat("wombat.js")
+        self.download_wombat("wombatWorkers.js")
         return super().initialize(version, build_data)
 
     def download_wombat(self, name):

--- a/src/warc2zim/content_rewriting/generic.py
+++ b/src/warc2zim/content_rewriting/generic.py
@@ -38,7 +38,8 @@ class Rewriter:
         if self.rewrite_mode == "css":
             return self.rewrite_css()
 
-        if self.rewrite_mode == "javascript":
+        if self.rewrite_mode in ["javascript", "module"]:
+            opts["isModule"] = self.rewrite_mode == "module"
             return self.rewrite_js(opts)
 
         return ("", self.content)
@@ -54,7 +55,10 @@ class Rewriter:
             return "css"
 
         if "javascript" in mimetype:
-            return "javascript"
+            if "module.js" in self.path:
+                return "module"
+            else:
+                return "javascript"
 
         return None
 

--- a/src/warc2zim/content_rewriting/html.py
+++ b/src/warc2zim/content_rewriting/html.py
@@ -67,7 +67,7 @@ class HtmlRewriter(HTMLParser):
         self.output = None
         # This works only for tag without children.
         # But as we use it to get the title, we are ok
-        self._active_tag = None
+        self.rewrite_context = None
         self.pre_head_insert = pre_head_insert
         self.post_head_insert = post_head_insert
 
@@ -89,7 +89,12 @@ class HtmlRewriter(HTMLParser):
         self.output.write(value)  # pyright: ignore[reportOptionalMemberAccess]
 
     def handle_starttag(self, tag: str, attrs: AttrsList, *, auto_close: bool = False):
-        self._active_tag = tag
+        if tag == "title":
+            self.rewrite_context = "title"
+        elif tag == "style":
+            self.rewrite_context = "style"
+        elif tag == "script":
+            self.rewrite_context = "scrip"
 
         self.send(f"<{tag}")
         if attrs:
@@ -110,21 +115,21 @@ class HtmlRewriter(HTMLParser):
             self.send(self.pre_head_insert)
 
     def handle_endtag(self, tag: str):
-        self._active_tag = None
+        self.rewrite_context = None
         if tag == "head" and self.post_head_insert:
             self.send(self.post_head_insert)
         self.send(f"</{tag}>")
 
     def handle_startendtag(self, tag: str, attrs: AttrsList):
         self.handle_starttag(tag, attrs, auto_close=True)
-        self._active_tag = None
+        self.rewrite_context = None
 
     def handle_data(self, data: str):
-        if self._active_tag == "title" and self.title is None:
+        if self.rewrite_context == "title" and self.title is None:
             self.title = data.strip()
-        elif self._active_tag == "style":
+        elif self.rewrite_context == "style":
             data = self.css_rewriter.rewrite(data)
-        elif self._active_tag == "script":
+        elif self.rewrite_context == "script":
             if data.strip():
                 data = JsRewriter(self.url_rewriter).rewrite(data)
         self.send(data)

--- a/src/warc2zim/content_rewriting/js.py
+++ b/src/warc2zim/content_rewriting/js.py
@@ -278,7 +278,7 @@ class JsRewriter(RxRewriter):
             def func(m_object, _opts):
                 def sub_funct(match):
                     return (
-                        f"{match.group(1)}{self.url_rewriter(match.group(2))}"
+                        f"{match.group(1)}{self.url_rewriter(match.group(2), force_relative_path=True)}"
                         f"{match.group(3)}"
                     )
 

--- a/src/warc2zim/url_rewriting.py
+++ b/src/warc2zim/url_rewriting.py
@@ -164,7 +164,9 @@ class ArticleUrlRewriter:
             # We want a directory
             self.base_path = posixpath.dirname(self.base_path)
 
-    def __call__(self, url: str, *, rewrite_all_url: bool = True) -> str:
+    def __call__(
+        self, url: str, *, rewrite_all_url: bool = True, force_relative_path=False
+    ) -> str:
         """Rewrite a url contained in a article.
 
         The url is "fully" rewrited to point to a normalized entry path
@@ -180,13 +182,17 @@ class ArticleUrlRewriter:
         normalized_url = normalize(absolute_url)
 
         if rewrite_all_url or get_without_fragment(normalized_url) in self.known_urls:
-            return self.from_normalized(normalized_url)
+            return self.from_normalized(
+                normalized_url, force_relative_path=force_relative_path
+            )
         else:
             logger.debug(f"WARNING {normalized_url} ({url}) not in archive.")
             # The url doesn't point to a known entry
             return url
 
-    def from_normalized(self, normalized_url_str: str) -> str:
+    def from_normalized(
+        self, normalized_url_str: str, *, force_relative_path=False
+    ) -> str:
         normalized_url = urlsplit(f"/{normalized_url_str}")
 
         # relative_to will lost our potential last '/'
@@ -195,6 +201,8 @@ class ArticleUrlRewriter:
 
         if slash_ending:
             relative_path += "/"
+        if force_relative_path and relative_path[0] != ".":
+            relative_path = "./" + relative_path
         normalized_url = normalized_url._replace(path=relative_path)
         normalized_url = urlunsplit(normalized_url)
 

--- a/tests/test_js_rewriting.py
+++ b/tests/test_js_rewriting.py
@@ -187,7 +187,7 @@ B = await import(somefile);
 import * from "../../../example.com/file.js"
 import A from "../../../example.com/path/file2.js";
 
-import {C, D} from "abc.js";
+import {C, D} from "./abc.js";
 import {X, Y} from "../parent.js";
 import {E, F, G} from "../../path.js";
 import { Z } from "../../path.js";
@@ -198,7 +198,8 @@ B = await ____wb_rewrite_import__(import.meta.url, somefile);
         ImportTestContent(
             'import"import.js";import{A, B, C} from"test.js";(function() => { frames[0]'
             '.href = "/abc"; })',
-            'import"import.js";import{A, B, C} from"test.js";(function() => { frames[0]'
+            ## This is not rewriten as `./test.js`. It is because of a bug ???
+            'import"import.js";import{A, B, C} from"./test.js";(function() => { frames[0]'
             '.href = "/abc"; })',
         ),
         ImportTestContent(

--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -241,6 +241,7 @@ class TestWarc2Zim:
             "example.com/": "Example Domain",
             "_zim_static/__wb_module_decl.js": "_zim_static/__wb_module_decl.js",
             "_zim_static/wombat.js": "_zim_static/wombat.js",
+            "_zim_static/wombatWorkers.js": "_zim_static/wombatWorkers.js",
             "_zim_static/wombat_setup.js": "_zim_static/wombat_setup.js",
         }
 


### PR DESCRIPTION
This PR is **kind of** a fix to #165.

The root issue seems that vimeo is using js module (instead of plain "classic" script) and rewriter is not detecting thing correctly.

If it is somehow easily fixable for inline module, we have to detect that for js resources themselves. We have regex in JS rewriter to detect that, but it seems it is not working. The check
```python
if "module.js" in self.path:
    return "module"
else:
    return "javascript"
```
works in our use case, but probably (definitively?) not something we want in production.
I'm still searching for a good way to detect that.
For wabac.js, it is easier as js is rewritten as runtime, so it knows the context.

On top of that, the player seems to be broken sometime, depending if you are clicking on the "video background" or the "play" button. Alternate clicking on video/play button launch the video.