### PR TITLE
[HACK] Rewrite vimeo iframe with video html tag

### DIFF
--- a/src/warc2zim/content_rewriting/generic.py
+++ b/src/warc2zim/content_rewriting/generic.py
@@ -21,6 +21,7 @@ class Rewriter:
 
         mimetype = get_record_mime_type(record)
 
+        self.known_urls = known_urls
         self.path = path
         self.orig_url_str = get_record_url(record)
         self.url_rewriter = ArticleUrlRewriter(self.orig_url_str, known_urls)
@@ -69,9 +70,9 @@ class Rewriter:
             orig_scheme=orig_url.scheme,
             orig_host=orig_url.netloc,
         )
-        return HtmlRewriter(self.url_rewriter, head_insert, css_insert).rewrite(
-            self.content
-        )
+        return HtmlRewriter(
+            self.known_urls, self.url_rewriter, head_insert, css_insert
+        ).rewrite(self.content)
 
     def rewrite_css(self):
         return ("", CssRewriter(self.url_rewriter).rewrite(self.content))

--- a/src/warc2zim/content_rewriting/html.py
+++ b/src/warc2zim/content_rewriting/html.py
@@ -122,7 +122,22 @@ class HtmlRewriter(HTMLParser):
                         f"vimeo-cdn.fuzzy.replayweb.page/.*?/{player_id}/", url
                     )
                 )
+            elif "www.youtube.com/embed" in iframe_src:
+                breakpoint()
+                # Let's be hacking, the videoID is hidden in json in `youtubei/v1/player?videoId={playerId}`.
+                # But, for now, we have only one video let's use it
+                player_id = re.search(
+                    "www.youtube.com/embed/([^?]+)", iframe_src
+                ).group(1)
+                video_url = next(
+                    url
+                    for url in self.known_urls
+                    if url.startswith("youtube.fuzzy.replayweb.page/videoplayback")
+                )
+            else:
+                video_url = None
 
+            if video_url:
                 self.handle_starttag(
                     "video",
                     [


### PR DESCRIPTION
The PR is HACK (a.k.a. a hammer to smash a fly).
It replace the `<iframe>` loading the vimeo js player with simple html video tag pointing to the video file.

It doesn't really respect the initial content, but it works damn well.

The code is a bit ugly and need some re-organisation. But I will do it if we agree with the idea.

Your comments are welcomed.

(ping @jaifroid)