### PR TITLE
Be more tolerant to invalid css.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,4 +240,5 @@ include = ["src", "tests", "tasks.py"]
 exclude = [".env/**", ".venv/**"]
 extraPaths = ["src"]
 pythonVersion = "3.11"
-typeCheckingMode="basic"
+typeCheckingMode = "basic"
+disableBytesTypePromotions = true

--- a/src/warc2zim/__about__.py
+++ b/src/warc2zim/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-dev2"
+__version__ = "2.0.0-dev3"

--- a/src/warc2zim/content_rewriting/css.py
+++ b/src/warc2zim/content_rewriting/css.py
@@ -10,6 +10,7 @@ from tinycss2 import (
 )
 from tinycss2.serializer import serialize_url
 
+from warc2zim.constants import logger
 from warc2zim.content_rewriting import UrlRewriterProto
 from warc2zim.content_rewriting.rx_replacer import RxRewriter
 
@@ -51,6 +52,13 @@ class CssRewriter:
             # If tinycss fail to parse css, it will generate a "Error" token.
             # Exception is raised at serialization time.
             # We try/catch the whole process to be sure anyway.
+            logger.warning(
+                (
+                    "Css transformation fails. Fallback to regex rewriter.\n"
+                    "Article path is %s"
+                ),
+                self.url_rewriter.article_url,
+            )
             return self.fallback_rewriter.rewrite_content(content, {})
         return output
 
@@ -64,6 +72,13 @@ class CssRewriter:
             # If tinycss fail to parse css, it will generate a "Error" token.
             # Exception is raised at serialization time.
             # We try/catch the whole process to be sure anyway.
+            logger.warning(
+                (
+                    "Css transformation fails. Fallback to regex rewriter.\n"
+                    "Content is `%s`"
+                ),
+                content,
+            )
             return self.fallback_rewriter.rewrite_content(content, {})
 
     def process_list(self, components: Iterable[ast.Node]):

--- a/src/warc2zim/content_rewriting/rx_replacer.py
+++ b/src/warc2zim/content_rewriting/rx_replacer.py
@@ -119,12 +119,14 @@ class RxRewriter:
 
     def rewrite_content(
         self,
-        text: str,
+        text: str | bytes,
         opts: dict[str, Any],
     ) -> str:
         """
         Apply the unique `compiled_rules` pattern and replace the content.
         """
+        if isinstance(text, bytes):
+            text = text.decode()
 
         def replace(m_object):
             """

--- a/tests/test_html_rewriting.py
+++ b/tests/test_html_rewriting.py
@@ -38,9 +38,9 @@ def no_rewrite_content(request):
 def test_no_rewrite(no_rewrite_content):
     assert (
         HtmlRewriter(ArticleUrlRewriter(no_rewrite_content.article_url, set()), "", "")
-        .rewrite(no_rewrite_content.input_)
+        .rewrite(no_rewrite_content.input_str)
         .content
-        == no_rewrite_content.expected
+        == no_rewrite_content.expected_str
     )
 
 
@@ -71,10 +71,10 @@ def escaped_content(request):
 def test_escaped_content(escaped_content):
     transformed = (
         HtmlRewriter(ArticleUrlRewriter(escaped_content.article_url, set()), "", "")
-        .rewrite(escaped_content.input_)
+        .rewrite(escaped_content.input_str)
         .content
     )
-    assert transformed == escaped_content.expected
+    assert transformed == escaped_content.expected_str
 
 
 def long_path_replace_test_content(input_: str, rewriten_url: str, article_url: str):
@@ -161,9 +161,9 @@ def test_rewrite(rewrite_url):
             "",
             "",
         )
-        .rewrite(rewrite_url.input_)
+        .rewrite(rewrite_url.input_str)
         .content
-        == rewrite_url.expected
+        == rewrite_url.expected_str
     )
 
 

--- a/tests/test_js_rewriting.py
+++ b/tests/test_js_rewriting.py
@@ -26,8 +26,8 @@ def rewrite_this_js_content(request):
 
 def test_this_js_rewrite(rewrite_this_js_content):
     assert (
-        JsRewriter(lambda x: x).rewrite(rewrite_this_js_content.input_)
-        == rewrite_this_js_content.expected
+        JsRewriter(lambda x: x).rewrite(rewrite_this_js_content.input_str)
+        == rewrite_this_js_content.expected_str
     )
 
 
@@ -65,7 +65,7 @@ class WrappedTestContent(ContentForTests):
 
     def __post_init__(self):
         super().__post_init__()
-        self.expected = self.wrap_script(self.expected)
+        self.expected = self.wrap_script(self.expected_str)
 
 
 @pytest.fixture(
@@ -105,8 +105,8 @@ def rewrite_wrapped_content(request):
 
 def test_wrapped_rewrite(rewrite_wrapped_content):
     assert (
-        JsRewriter(lambda x: x).rewrite(rewrite_wrapped_content.input_)
-        == rewrite_wrapped_content.expected
+        JsRewriter(lambda x: x).rewrite(rewrite_wrapped_content.input_str)
+        == rewrite_wrapped_content.expected_str
     )
 
 
@@ -131,7 +131,7 @@ class ImportTestContent(ContentForTests):
     def __post_init__(self):
         super().__post_init__()
         self.article_url = "https://exemple.com/some/path/"
-        self.expected = self.wrap_import(self.expected)
+        self.expected = self.wrap_import(self.expected_str)
 
 
 @pytest.fixture(
@@ -220,8 +220,8 @@ def rewrite_import_content(request):
 def test_import_rewrite(rewrite_import_content):
     url_rewriter = ArticleUrlRewriter(rewrite_import_content.article_url, set())
     assert (
-        JsRewriter(url_rewriter).rewrite(rewrite_import_content.input_)
-        == rewrite_import_content.expected
+        JsRewriter(url_rewriter).rewrite(rewrite_import_content.input_str)
+        == rewrite_import_content.expected_str
     )
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,10 +3,34 @@ from dataclasses import dataclass
 
 @dataclass
 class ContentForTests:
-    input_: str
-    expected: str = ""
+    input_: str | bytes
+    expected: str | bytes = ""
     article_url: str = "kiwix.org"
 
     def __post_init__(self):
         if not self.expected:
             self.expected = self.input_
+
+    @property
+    def input_str(self) -> str:
+        if isinstance(self.input_, str):
+            return self.input_
+        raise ValueError("Input value is not a str.")
+
+    @property
+    def input_bytes(self) -> bytes:
+        if isinstance(self.input_, bytes):
+            return self.input_
+        raise ValueError("Input value is not a bytes.")
+
+    @property
+    def expected_str(self) -> str:
+        if isinstance(self.expected, str):
+            return self.expected
+        raise ValueError("Expected value is not a str.")
+
+    @property
+    def expected_bytes(self) -> bytes:
+        if isinstance(self.expected, bytes):
+            return self.expected
+        raise ValueError("Expected value is not a bytes.")


### PR DESCRIPTION
Return the original content if we cannot parse the css.

---

In case of invalid css tinycss2 doesn't not failed on parsing, but generate a ParserError token
https://doc.courtbouillon.org/tinycss2/stable/api_reference.html?highlight=parser#tinycss2.ast.ParseError

This is on serialization that exception occurs.
We even try/except all transformation to be sure.

Fix #155