### PR TITLE
Correctly detect encoding and decode bytes 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "Babel==2.12.1",
   "jinja2==3.1.2",
   "setuptools==68.2.2",
+  "chardet==5.2.0",
   # to support possible brotli content in warcs
   "brotlipy==0.7.0",
   "cdxj_indexer==1.4.5",

--- a/src/warc2zim/content_rewriting/generic.py
+++ b/src/warc2zim/content_rewriting/generic.py
@@ -7,7 +7,12 @@ from warc2zim.content_rewriting.css import CssRewriter
 from warc2zim.content_rewriting.ds import build_domain_specific_rewriter
 from warc2zim.content_rewriting.html import HtmlRewriter
 from warc2zim.url_rewriting import ArticleUrlRewriter
-from warc2zim.utils import get_record_content, get_record_mime_type, get_record_url
+from warc2zim.utils import (
+    get_record_content,
+    get_record_mime_type,
+    get_record_url,
+    to_string,
+)
 
 
 class Rewriter:
@@ -70,7 +75,7 @@ class Rewriter:
             orig_host=orig_url.netloc,
         )
         return HtmlRewriter(self.url_rewriter, head_insert, css_insert).rewrite(
-            self.content
+            to_string(self.content)
         )
 
     def rewrite_css(self):

--- a/src/warc2zim/content_rewriting/generic.py
+++ b/src/warc2zim/content_rewriting/generic.py
@@ -9,6 +9,7 @@ from warc2zim.content_rewriting.html import HtmlRewriter
 from warc2zim.url_rewriting import ArticleUrlRewriter
 from warc2zim.utils import (
     get_record_content,
+    get_record_encoding,
     get_record_mime_type,
     get_record_url,
     to_string,
@@ -25,6 +26,8 @@ class Rewriter:
         self.content = get_record_content(record)
 
         mimetype = get_record_mime_type(record)
+
+        self.encoding = get_record_encoding(record)
 
         self.path = path
         self.orig_url_str = get_record_url(record)
@@ -75,7 +78,7 @@ class Rewriter:
             orig_host=orig_url.netloc,
         )
         return HtmlRewriter(self.url_rewriter, head_insert, css_insert).rewrite(
-            to_string(self.content)
+            to_string(self.content, self.encoding)
         )
 
     def rewrite_css(self):
@@ -85,5 +88,5 @@ class Rewriter:
         rewriter = build_domain_specific_rewriter(self.path, self.url_rewriter)
         return (
             "",
-            rewriter.rewrite(self.content.decode(), opts),
+            rewriter.rewrite(to_string(self.content, self.encoding), opts),
         )

--- a/src/warc2zim/content_rewriting/html.py
+++ b/src/warc2zim/content_rewriting/html.py
@@ -7,7 +7,6 @@ from warc2zim.content_rewriting import UrlRewriterProto
 from warc2zim.content_rewriting.css import CssRewriter
 from warc2zim.content_rewriting.js import JsRewriter
 from warc2zim.url_rewriting import ArticleUrlRewriter
-from warc2zim.utils import to_string
 
 AttrsList = list[tuple[str, str | None]]
 
@@ -71,12 +70,10 @@ class HtmlRewriter(HTMLParser):
         self.pre_head_insert = pre_head_insert
         self.post_head_insert = post_head_insert
 
-    def rewrite(self, content: str | bytes) -> RewritenHtml:
+    def rewrite(self, content: str) -> RewritenHtml:
         if self.output is not None:
             raise Exception("ouput should not already be set")  # pragma: no cover
         self.output = io.StringIO()
-
-        content = to_string(content)
 
         self.feed(content)
         self.close()

--- a/src/warc2zim/url_rewriting.py
+++ b/src/warc2zim/url_rewriting.py
@@ -57,8 +57,6 @@ from urllib.parse import (
     urlunsplit,
 )
 
-from warc2zim.utils import to_string
-
 # Shared logger
 logger = logging.getLogger("warc2zim.url_rewriting")
 
@@ -115,7 +113,7 @@ def reduce(path: str) -> str:
     return path
 
 
-def normalize(url: str | bytes | None) -> str:
+def normalize(url: str | None) -> str:
     """Normalize a properly contructed url to a path to use as a entry's key.
 
     >>> normalize("http://exemple.com/path/to/article?foo=bar")
@@ -129,8 +127,6 @@ def normalize(url: str | bytes | None) -> str:
 
     if not url:
         return url  # pyright: ignore[reportGeneralTypeIssues, reportReturnType]
-
-    url = to_string(url)
 
     url_parts = urlsplit(url)
     url_parts = url_parts._replace(scheme="")

--- a/src/warc2zim/utils.py
+++ b/src/warc2zim/utils.py
@@ -3,10 +3,17 @@
 
 from __future__ import annotations
 
+import re
+
 from bs4 import BeautifulSoup
 from warcio.recordloader import ArcWarcRecord
 
 from warc2zim.__about__ import __version__
+
+ENCODING_RE = re.compile(
+    r"(charset|encoding)=(?P<quote>['\"]?)(?P<encoding>[a-wA-Z0-9_\-]+)(?P=quote)",
+    re.ASCII,
+)
 
 
 def get_version():
@@ -44,6 +51,11 @@ def parse_title(content):
     except Exception:
         return ""
 
+
+def get_record_encoding(record: ArcWarcRecord) -> str | None:
+    content_type = get_record_content_type(record)
+    if m := ENCODING_RE.search(content_type):
+        return m.group("encoding")
 
 def to_string(input_: str | bytes) -> str:
     try:

--- a/src/warc2zim/utils.py
+++ b/src/warc2zim/utils.py
@@ -87,13 +87,16 @@ def to_string(input_: str | bytes, encoding: str | None) -> str:
     # Detect encoding from content.
     content_start = input_[:1024].decode("ascii", errors="replace")
     if m := ENCODING_RE.search(content_start):
-        encoding = m.group("encoding")
+        encodings = [m.group("encoding")]
     else:
-        encoding = chardet.detect(input_)["encoding"]
+        encodings = [e["encoding"] for e in chardet.detect_all(input_)]
 
-    if not encoding:
-        raise ValueError(f"Impossible to detect encoding of content {input_[:200]}")
-    return input_.decode(encoding)
+    for encoding in encodings:
+        try:
+            return input_.decode(encoding)
+        except ValueError:
+            pass
+    raise ValueError(f"Impossible to decode content {input_[:200]}")
 
 
 def get_record_content(record: ArcWarcRecord):

--- a/src/warc2zim/utils.py
+++ b/src/warc2zim/utils.py
@@ -74,6 +74,10 @@ def to_string(input_: str | bytes, encoding: str | None) -> str:
     if isinstance(input_, str):
         return input_
 
+    if not input_:
+        # Empty bytes are easy to decode
+        return ""
+
     if encoding:
         try:
             return input_.decode(encoding)

--- a/src/warc2zim/utils.py
+++ b/src/warc2zim/utils.py
@@ -21,7 +21,7 @@ def get_record_url(record):
     return record.rec_headers["WARC-Target-URI"]
 
 
-def get_record_mime_type(record):
+def get_record_content_type(record: ArcWarcRecord) -> str:
     if record.http_headers:
         # if the record has HTTP headers, use the Content-Type from those
         # (eg. 'response' record)
@@ -29,9 +29,12 @@ def get_record_mime_type(record):
     else:
         # otherwise, use the Content-Type from WARC headers
         content_type = record.rec_headers["Content-Type"]
+    return content_type or ""
 
-    mime = content_type or ""
-    return mime.split(";")[0]
+
+def get_record_mime_type(record: ArcWarcRecord) -> str:
+    content_type = get_record_content_type(record)
+    return content_type.split(";")[0]
 
 
 def parse_title(content):

--- a/src/warc2zim/utils.py
+++ b/src/warc2zim/utils.py
@@ -87,9 +87,16 @@ def to_string(input_: str | bytes, encoding: str | None) -> str:
     # Detect encoding from content.
     content_start = input_[:1024].decode("ascii", errors="replace")
     if m := ENCODING_RE.search(content_start):
-        encodings = [m.group("encoding")]
-    else:
-        encodings = [e["encoding"] for e in chardet.detect_all(input_)]
+        encoding = m.group("encoding")
+        if encoding:
+            try:
+                return input_.decode(encoding)
+            except ValueError:
+                pass
+
+    encodings = (
+        encoding for e in chardet.detect_all(input_) if (encoding := e["encoding"])
+    )
 
     for encoding in encodings:
         try:

--- a/src/warc2zim/utils.py
+++ b/src/warc2zim/utils.py
@@ -82,7 +82,7 @@ def to_string(input_: str | bytes, encoding: str | None) -> str:
     if encoding:
         try:
             return input_.decode(encoding)
-        except ValueError:
+        except (ValueError, LookupError):
             tried_encodings.add(encoding)
             pass
 
@@ -93,7 +93,7 @@ def to_string(input_: str | bytes, encoding: str | None) -> str:
         if encoding and encoding not in tried_encodings:
             try:
                 return input_.decode(encoding)
-            except ValueError:
+            except (ValueError, LookupError):
                 tried_encodings.add(encoding)
                 pass
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,248 @@
+from dataclasses import dataclass
+
+import pytest
+
+from warc2zim.utils import to_string
+
+
+@dataclass
+class EncodedForTest:
+    content: str
+    encoding: str
+    encoded: bytes
+    valid: bool
+
+    def __init__(self, content: str, encoding: str):
+        self.content = content
+        self.encoding = encoding
+        try:
+            self.encoded = content.encode(encoding)
+            self.valid = True
+        except ValueError:
+            self.valid = False
+
+
+@pytest.fixture(
+    params=[
+        "Simple ascii content",
+        "A content with non ascii char éœo€ð",
+        "这是中文文本",  # "This is a chinese text" (in chinese)
+    ]
+)
+def content(request):
+    yield request.param
+
+
+@pytest.fixture(
+    params=[
+        "ascii",
+        "utf-8",
+        "utf-16",
+        "utf-32",
+        "latin1",
+        "gb2312",
+        "gbk",
+    ]
+)
+def encoding(request):
+    yield request.param
+
+
+@pytest.fixture
+def simple_encoded_content(content, encoding):
+    return EncodedForTest(content, encoding)
+
+
+def test_decode(simple_encoded_content):
+    if not simple_encoded_content.valid:
+        # Nothing to test
+        return
+    assert (
+        to_string(simple_encoded_content.encoded, None)
+        == simple_encoded_content.content
+    )
+
+
+@pytest.fixture(
+    params=[
+        "ascii",
+        "utf-8",
+        "utf-16",
+        "utf-32",
+        "latin1",
+        "gb2312",
+        "gbk",
+        "wrong-encoding",
+    ]
+)
+def declared_encoding(request):
+    return request.param
+
+
+# This is a set of content/encoding/decoding that we know to fail.
+# For exemple, the content "Simple ascii content" encoded using ascii, can be decoded
+# by utf-16. However, it doesn't mean that it decoded it correctly.
+# In this case, "utf-16" decoded it as "...."
+# And this combination is not only based on the tuple encoding/decoding.
+# The content itself may inpact if we can decode the bytes, and so if we try heuristics
+# or not. No real choice to maintain a dict of untestable configuration.
+FAILING_DECODE_COMBINATION = {
+    # Encodings/decodings failing for simple ascii content
+    "Simple ascii content": {
+        # Decoding failing for simple ascii content encoded in ascii
+        "ascii": ["utf-16"],
+        # Decoding failing for simple ascii content encoded in utf-8
+        "utf-8": [
+            "utf-16",
+            "utf-32",
+            "gb2312",
+            "gbk",
+        ],
+        "utf-16": ["latin1"],
+        "utf-32": ["utf-16", "latin1"],
+        "latin1": ["utf-16"],
+        "gb2312": ["utf-16"],
+        "gbk": ["utf-16"],
+    },
+    "A content with non ascii char éœo€ð": {
+        "ascii": [],
+        "utf-8": ["utf-16", "latin1"],
+        "utf-16": ["latin1"],
+        "utf-32": ["utf-16", "latin1"],
+        "latin1": [],
+        "gb2312": [],
+        "gbk": [],
+    },
+    "这是中文文本": {
+        "ascii": [],
+        "utf-8": ["utf-16", "latin1"],
+        "utf-16": ["latin1"],
+        "utf-32": ["utf-16", "latin1"],
+        "latin1": [],
+        "gb2312": ["utf-16", "latin1"],
+        "gbk": ["utf-16", "latin1"],
+    },
+}
+
+
+@dataclass
+class DeclaredEncodedForTest(EncodedForTest):
+    declared_encoding: str
+    correct: bool
+
+    def __init__(self, content: str, encoding: str, declared_encoding: str):
+        super().__init__(content, encoding)
+        self.declared_encoding = declared_encoding
+        self.correct = self.valid
+        if (
+            self.valid
+            and content in FAILING_DECODE_COMBINATION
+            and declared_encoding in FAILING_DECODE_COMBINATION[content][encoding]
+        ):
+            self.correct = False
+
+
+@pytest.fixture
+def declared_encoded_content(content, encoding, declared_encoding):
+    return DeclaredEncodedForTest(content, encoding, declared_encoding)
+
+
+def test_declared_decode(declared_encoded_content):
+    test_case = declared_encoded_content
+    if not test_case.valid:
+        return
+
+    decoded = to_string(test_case.encoded, test_case.declared_encoding)
+    if test_case.correct:
+        assert decoded == test_case.content
+
+
+# This is a set of content/encoding/decoding that we know to fail.
+# For exemple, the content "Simple ascii content" encoded using ascii, can be decoded
+# by utf-16. However, it doesn't mean that it decoded it correctly.
+# In this case, "utf-16" decoded it as "...."
+# And this combination is not only based on the tuple encoding/decoding.
+# The content itself may inpact if we can decode the bytes, and so if we try heuristics
+# or not. No real choice to maintain a dict of untestable configuration.
+FAILING_DECODE_HTML_COMBINATION = {
+    # All encoding/declared_encodingcoding failing for simple ascii content
+    "Simple ascii content": {
+        "ascii": [],
+        "utf-8": [],
+        "utf-16": [],
+        "utf-32": [],
+        "latin1": [],
+        "gb2312": [],
+        "gbk": [],
+    },
+    "A content with non ascii char éœo€ð": {
+        "ascii": [],
+        "utf-8": ["latin1"],
+        "utf-16": [],
+        "utf-32": [],
+        "latin1": [],
+        "gb2312": [],
+        "gbk": [],
+    },
+    "这是中文文本": {
+        "ascii": [],
+        "utf-8": ["latin1"],
+        "utf-16": [],
+        "utf-32": [],
+        "latin1": [],
+        "gb2312": ["latin1"],
+        "gbk": ["latin1"],
+    },
+}
+
+
+@dataclass
+class DeclaredHtmlEncodedForTest(DeclaredEncodedForTest):
+    declared_encoding: str
+    correct: bool
+
+    def __init__(self, content: str, encoding: str, declared_encoding: str):
+        html_content = (
+            f'<html><meta charset="{declared_encoding}"><body>{content}</body></html>'
+        )
+
+        super().__init__(html_content, encoding, declared_encoding)
+        self.correct = self.valid
+        if (
+            self.valid
+            and declared_encoding in FAILING_DECODE_HTML_COMBINATION[content][encoding]
+        ):
+            self.correct = False
+
+
+@pytest.fixture
+def declared_html_encoded_content(content, encoding, declared_encoding):
+    return DeclaredHtmlEncodedForTest(content, encoding, declared_encoding)
+
+
+def test_declared_decode_html(declared_html_encoded_content):
+    test_case = declared_html_encoded_content
+    if not test_case.valid:
+        return
+
+    html_decoded = to_string(test_case.encoded, None)
+    if test_case.correct:
+        assert html_decoded == test_case.content
+
+
+def test_decode_str(content, declared_encoding):
+    assert to_string(content, declared_encoding) == content
+
+
+def test_binary_content():
+    content = "Hello, 你好".encode("utf-32")
+    content = bytes([0xEF, 0xBB, 0xBF]) + content
+    # [0xEF, 0xBB, 0xBF] is a BOM marker for utf-8
+    # It will trick chardet to be really confident it is utf-8.
+    # However, this cannot be decoded using utf-8
+    with pytest.raises(ValueError):
+        assert to_string(content, None)
+
+    with pytest.raises(ValueError):
+        # Make coverage pass on code avoiding us to try the same encoding twice
+        assert to_string(content, "UTF-8-SIG")

--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -177,7 +177,6 @@ class TestWarc2Zim:
         assert normalize("https://exemple.com") == "exemple.com"
         assert normalize("https://exemple.com/") == "exemple.com/"
         assert normalize("http://example.com/?foo=bar") == "example.com/?foo=bar"
-        assert normalize(b"http://example.com/?foo=bar") == "example.com/?foo=bar"
 
         assert normalize("https://example.com/?foo=bar") == "example.com/?foo=bar"
 


### PR DESCRIPTION
This PR try to detect encoding using 3 methods:
- From http headers in the warc record
- From encoding declaration inside the content
- From statistical analysis of the content (made by chardet)

Fix #177