### PR TITLE
Correctly rewrite json.

### DIFF
--- a/src/warc2zim/content_rewriting/css.py
+++ b/src/warc2zim/content_rewriting/css.py
@@ -59,7 +59,7 @@ class CssRewriter:
                 ),
                 self.url_rewriter.article_url,
             )
-            return self.fallback_rewriter.rewrite_content(content, {})
+            return self.fallback_rewriter.rewrite(content, {})
         return output
 
     def rewrite_inline(self, content: str) -> str:
@@ -79,7 +79,7 @@ class CssRewriter:
                 ),
                 content,
             )
-            return self.fallback_rewriter.rewrite_content(content, {})
+            return self.fallback_rewriter.rewrite(content, {})
 
     def process_list(self, components: Iterable[ast.Node]):
         if components:  # May be null

--- a/src/warc2zim/content_rewriting/generic.py
+++ b/src/warc2zim/content_rewriting/generic.py
@@ -1,12 +1,14 @@
 from collections.abc import Callable
+from typing import Any
 from urllib.parse import urlsplit
 
 from jinja2.environment import Template
 from warcio.recordloader import ArcWarcRecord
 
 from warc2zim.content_rewriting.css import CssRewriter
-from warc2zim.content_rewriting.ds import build_domain_specific_rewriter
+from warc2zim.content_rewriting.ds import get_ds_rules
 from warc2zim.content_rewriting.html import HtmlRewriter
+from warc2zim.content_rewriting.js import JsRewriter
 from warc2zim.url_rewriting import ArticleUrlRewriter
 from warc2zim.utils import (
     get_record_content,
@@ -114,5 +116,6 @@ class Rewriter:
 
     @no_title
     def rewrite_js(self, opts: dict[str, Any]) -> str | bytes:
-        rewriter = build_domain_specific_rewriter(self.path, self.url_rewriter)
+        ds_rules = get_ds_rules(self.orig_url_str)
+        rewriter = JsRewriter(self.url_rewriter, ds_rules)
         return rewriter.rewrite(self.content.decode(), opts)

--- a/src/warc2zim/content_rewriting/html.py
+++ b/src/warc2zim/content_rewriting/html.py
@@ -5,6 +5,7 @@ from html.parser import HTMLParser
 
 from warc2zim.content_rewriting import UrlRewriterProto
 from warc2zim.content_rewriting.css import CssRewriter
+from warc2zim.content_rewriting.ds import get_ds_rules
 from warc2zim.content_rewriting.js import JsRewriter
 from warc2zim.url_rewriting import ArticleUrlRewriter
 
@@ -122,8 +123,9 @@ class HtmlRewriter(HTMLParser):
         elif self._active_tag == "style":
             data = self.css_rewriter.rewrite(data)
         elif self._active_tag == "script":
+            rules = get_ds_rules(self.url_rewriter.article_url)
             if data.strip():
-                data = JsRewriter(self.url_rewriter).rewrite(data)
+                data = JsRewriter(self.url_rewriter, rules).rewrite(data)
         self.send(data)
 
     def handle_entityref(self, name: str):

--- a/src/warc2zim/content_rewriting/js.py
+++ b/src/warc2zim/content_rewriting/js.py
@@ -187,6 +187,13 @@ def create_js_rules() -> list[TransformationRule]:
 REWRITE_JS_RULES = create_js_rules()
 
 
+def js_rewriter_builder(url_rewriter: UrlRewriterProto):
+    def build_js_rewriter(extra_rules):
+        return JsRewriter(url_rewriter, extra_rules)
+
+    return build_js_rewriter
+
+
 class JsRewriter(RxRewriter):
     """
     JsRewriter is in charge of rewriting the js code stored in our zim file.
@@ -260,7 +267,7 @@ class JsRewriter(RxRewriter):
 
         self._compile_rules(rules)
 
-        new_text = self.rewrite_content(text, opts)
+        new_text = super().rewrite(text, opts)
 
         if opts["isModule"]:
             return self._get_module_decl(GLOBAL_OVERRIDES) + new_text

--- a/src/warc2zim/content_rewriting/rx_replacer.py
+++ b/src/warc2zim/content_rewriting/rx_replacer.py
@@ -117,7 +117,7 @@ class RxRewriter:
         rx_buff = "|".join(f"({rule[0].pattern})" for rule in rules)
         self.compiled_rule = re.compile(f"(?:{rx_buff})", re.M)
 
-    def rewrite_content(
+    def rewrite(
         self,
         text: str | bytes,
         opts: dict[str, Any],

--- a/tests/test_html_rewriting.py
+++ b/tests/test_html_rewriting.py
@@ -33,6 +33,9 @@ from .utils import ContentForTests
         ContentForTests(
             "<p> This is a smiley (🙂) and it html hex value (&#x1F642;) </p>"
         ),
+        ContentForTests(
+            '<script type="json">{"window": "https://kiwix.org/path"}</script>'
+        ),
     ]
 )
 def no_rewrite_content(request):
@@ -65,6 +68,30 @@ def test_no_rewrite(no_rewrite_content):
         ContentForTests(
             "<ul style='list-style: \">\"'>",
             '<ul style="list-style: &quot;&gt;&quot;;">',
+        ),
+        ContentForTests(
+            '<script>{"window": "https://kiwix.org/path"}</script>',
+            (
+                "<script>var _____WB$wombat$assign$function_____ = function(name) "
+                "{return (self._wb_wombat && self._wb_wombat.local_init && "
+                "self._wb_wombat.local_init(name)) || self[name]; };\n"
+                "if (!self.__WB_pmw) { self.__WB_pmw = function(obj) "
+                "{ this.__WB_source = obj; return this; } }\n"
+                "{\n"
+                """let window = _____WB$wombat$assign$function_____("window");\n"""
+                "let globalThis = _____WB$wombat$assign$function_____"
+                """("globalThis");\n"""
+                """let self = _____WB$wombat$assign$function_____("self");\n"""
+                """let document = _____WB$wombat$assign$function_____("document");\n"""
+                """let location = _____WB$wombat$assign$function_____("location");\n"""
+                """let top = _____WB$wombat$assign$function_____("top");\n"""
+                """let parent = _____WB$wombat$assign$function_____("parent");\n"""
+                """let frames = _____WB$wombat$assign$function_____("frames");\n"""
+                """let opener = _____WB$wombat$assign$function_____("opener");\n"""
+                "let arguments;\n\n"
+                """{"window": "https://kiwix.org/path"}\n"""
+                "}</script>"
+            ),
         ),
     ]
 )


### PR DESCRIPTION
Inline json was rewriten as javascript. Now we rewrite it as json.

This PR also rewrite "plan" json file with domain specific rules and rewrite "jsonp" (json callback) content.
This two fixes come from wabac rewriting but don't seems to be necessary (at least for this fix) and are not tested.

You can find a mdn archive converted to zim using this PR at https://tmp.kiwix.org/ci/test-warc/mgautier/mdn_json.zim

Ping @jaifroid


Fix #181
Fix #160 