### PR TITLE
Ignore `resource` WARC records for now

### DIFF
--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -485,7 +485,7 @@ class Converter:
                 logger.debug(f"Skipping url {url}, outside included domains")
                 return
 
-        if record.rec_type != "revisit":
+        if record.rec_type == "response":
             if self.is_self_redirect(record, url):
                 logger.debug("Skipping self-redirect: " + url)
                 return
@@ -510,7 +510,8 @@ class Converter:
             self.indexed_urls.add(normalized_url)
 
         elif (
-            record.rec_headers["WARC-Refers-To-Target-URI"] != url
+            record.rec_type == "revisit"
+            and record.rec_headers["WARC-Refers-To-Target-URI"] != url
             and normalized_url not in self.revisits
         ):  # pragma: no branch
             self.revisits[normalized_url] = normalize(

--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -159,7 +159,7 @@ class TestWarc2Zim:
                 # We should check with the content of the targeted record...
                 # But difficult to test as we don't have it
                 assert payload
-            else:
+            elif record.rec_type == "response":
                 # We must have a payload
                 assert payload
                 payload_content = payload.content.tobytes()
@@ -168,6 +168,9 @@ class TestWarc2Zim:
                 # have exact match
                 if payload.mimetype.startswith("text/html"):
                     assert head_insert in payload_content
+            elif record.rec_type == "resource":
+                # we do not want to embed resources "as-is"
+                assert not payload
 
             warc_urls.add(url)
 


### PR DESCRIPTION
Fix #197 

`add_items_for_warc_record` is already called only for records of type `resource`, `response` and `revisit` (i.e. `request` records are ignored) due to the filtering logic of `iter_warc_records`.

The logic to add a real item to the ZIM was not called if record type is `revisit`, i.e. it was called only for `resource` and `response`. 

As explained in #197, `resource` WARC records must not be added as-is to the ZIM, they are not regular web responses (as their WARC type implies).

The logic is hence inverted to also be future-prood:
- apply the default logic to add an item to the ZIM only if record is a `response`
- apply the logic to compute revisits only if record is a `revisit`