### PR TITLE
Use Lookahead expression in fuzzy rules instead of Lookbehind

### DIFF
--- a/src/warc2zim/url_rewriting.py
+++ b/src/warc2zim/url_rewriting.py
@@ -63,8 +63,8 @@ logger = logging.getLogger("warc2zim.url_rewriting")
 
 FUZZY_RULES = [
     {
-        "pattern": r".*googlevideo.com/(videoplayback\?).*((?<=[?&])id=[^&]+).*",
-        "replace": r"youtube.fuzzy.replayweb.page/\1\2",
+        "pattern": r".*googlevideo.com/(videoplayback(?=\?)).*[?&](id=[^&]+).*",
+        "replace": r"youtube.fuzzy.replayweb.page/\1?\2",
     },
     {
         "pattern": r"(?:www\.)?youtube(?:-nocookie)?\.com/(get_video_info\?).*(video_id"

--- a/tests/test_fuzzy_rules.py
+++ b/tests/test_fuzzy_rules.py
@@ -1,0 +1,41 @@
+import re
+
+import pytest
+
+from warc2zim.url_rewriting import FUZZY_RULES
+
+from .utils import ContentForTests
+
+
+@pytest.fixture(
+    params=[
+        ContentForTests(
+            "foobargooglevideo.com/videoplayback?id=1576&key=value",
+            "youtube.fuzzy.replayweb.page/videoplayback?id=1576",
+        ),
+        ContentForTests(
+            "foobargooglevideo.com/videoplayback?some=thing&id=1576",
+            "youtube.fuzzy.replayweb.page/videoplayback?id=1576",
+        ),
+        ContentForTests(
+            "foobargooglevideo.com/videoplayback?some=thing&id=1576&key=value",
+            "youtube.fuzzy.replayweb.page/videoplayback?id=1576",
+        ),
+        # videoplayback is not followed by `?`
+        ContentForTests(
+            "foobargooglevideo.com/videoplaybackandfoo?some=thing&id=1576&key=value"
+        ),
+        # No googlevideo.com in url
+        ContentForTests(
+            "foobargoogle_video.com/videoplaybackandfoo?some=thing&id=1576&key=value"
+        ),
+    ]
+)
+def google_video_url(request):
+    yield request.param
+
+
+def test_googlevideo(google_video_url):
+    rule = FUZZY_RULES[0]
+    rewritten = re.sub(rule["pattern"], rule["replace"], google_video_url.input_str)
+    assert rewritten == google_video_url.expected_str


### PR DESCRIPTION
Lookbehind (https://caniuse.com/?search=Lookbehind) is not fully supported on "old" browsers.
But lookahead (https://caniuse.com/?search=Lookahead) is supported "everywhere" as it is part of original js regular expression.
    
The tricky part in this change is that we must match the `?` both as:
- Just after `videoplayback` (always)
- Potentially just before `id=...`.

Fix #174 
Ping @jaifroid