### PR TITLE
Add wombat.js back

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/warc2zim"]
+artifacts = [
+  "src/warc2zim/statics/**",
+]
 
 [tool.hatch.envs.default]
 features = ["dev"]


### PR DESCRIPTION
Fix #207 

Changes:
- include all `statics` files as artifacts for the wheel

Nota:
- the sdist still doesn't contain the `wombat.js` which is great