### PR TITLE
Remove useless hatchling dependency now that we are using hatch-openzim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,6 @@ dev = [
   "warc2zim[lint]",
   "warc2zim[test]",
   "warc2zim[check]",
-  # hatchling is a dev dependency only needed for hook development on developer machine
-  "hatchling==1.18.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
https://github.com/openzim/warc2zim/pull/201 forgot to remove the now useless hatchling dev dependency.