### PR TITLE
Add check for invalid zim file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added checks in `converter.py` to verify output directory existence, logging appropriate error messages and cleanly exit if checks fail.
+- Added check for invalid zim file names
 - Changed default publisher metadata from 'Kiwix' to 'openZIM'
 
 ## [1.5.5] - 2024-01-18

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -147,6 +147,20 @@ class Converter:
             )
             sys.exit(1)
 
+        # ensure ZIM file is creatable with the given name
+        try:
+            file_path = pathlib.Path(self.full_filename)
+            file_path.touch()
+            file_path.unlink()
+            logger.debug(
+                f"Confirming ZIM file can be created using name: {self.zim_file}"
+            )
+        except Exception:
+            logger.error(
+                f"Failed to create ZIM file with name: {self.zim_file}. Make sure the file name is valid."
+            )
+            raise SystemExit(3)
+
         self.inputs = args.inputs
         self.include_domains = args.include_domains
 

--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -510,6 +510,11 @@ class TestWarc2Zim(object):
             main(["--name", "test", "--output", "/no-such-dir"])
             assert e.code == 1
 
+        # error, name has invalid characters for Linux filesystem
+        with pytest.raises(SystemExit) as e:
+            main(["--name", "te/st", "--output", "./"])
+            assert e.code == 3
+
         # success, special error code for no output files
         assert main(["--name", "test", "--output", "./"]) == 100
 


### PR DESCRIPTION
This PR adds a check for invalid zim filenames. This check works by creating a temporary file with the name provided and deletes it immediately. If an exception is thrown, the program logs it and exits.

Fixes #232