### PR TITLE
No more failure due to url rewriting issue

### DIFF
--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -293,8 +293,11 @@ class TestWarc2Zim:
             ("https://xn--exmple-cva.com/resource", "exémple.com/resource"),
             ("https://exémple.com/", "exémple.com/"),
             ("https://exémple.com/resource", "exémple.com/resource"),
+            # host_ip is an invalid hostname according to spec
             ("https://host_ip/", "host_ip/"),
             ("https://host_ip/resource", "host_ip/resource"),
+            ("https://192.168.1.1/", "192.168.1.1/"),
+            ("https://192.168.1.1/resource", "192.168.1.1/resource"),
             ("http://example.com/res%24urce", "example.com/res$urce"),
             (
                 "http://example.com/resource?foo=b%24r",


### PR DESCRIPTION
## Rationale

Fix #247 

## Changes

- all URL rewriting issues are simply logged, but they do not cause the scraper to fail
- no more special handling of hostname rewriting issues
  - try to decode hostname only if it starts with "xn--" (the indicator used for IDNA puny-encoded see [here](https://web.archive.org/web/20100427154004/http://www.atm.tut.fi/list-archive/ietf-announce/msg13572.html))