### PR TITLE
Log unexpected WARC record status codes as warnings

### DIFF
--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -301,7 +301,7 @@ class Converter:
             zim_path = normalize(HttpUrl(url))
 
             status_code = get_status_code(record)
-            if not status_code or not can_process_status_code(status_code):
+            if not can_process_status_code(status_code):
                 continue
 
             if status_code_is_processable_redirect(status_code):
@@ -581,10 +581,17 @@ class Converter:
 
         if record.rec_type == "response":
             status_code = get_status_code(record)
-            if not status_code or not can_process_status_code(status_code):
-                logger.debug(
-                    f"Skipping record with bad HTTP return code {status_code} "
+            if not isinstance(status_code, HTTPStatus):
+                logger.warning(
+                    f"Skipping record with unexpected HTTP return code {status_code} "
                     f"{item_zim_path}"
+                )
+                return
+
+            if not can_process_status_code(status_code):
+                logger.debug(
+                    f"Skipping record with unprocessable HTTP return code {status_code}"
+                    f" {item_zim_path}"
                 )
                 return
 


### PR DESCRIPTION
Fix #254 

- log unexpected (not an HTTPStatus) WARC record status code at WARNING log level (instead of DEBUG)
- `get_status_code` always return a value as intelligible as possible (i.e. an int value when we fail to convert it to HTTPStatus but is still an int) => useful for logs typically
- simplify `status_code_is_processable_redirect` by removing the repetition between `is_redirection` and the list of redirect codes we want to handle