### PR TITLE
Fix inclusion of custom CSS in warc2zim2

### DIFF
--- a/src/warc2zim/content_rewriting/generic.py
+++ b/src/warc2zim/content_rewriting/generic.py
@@ -83,7 +83,7 @@ class Rewriter:
     def content_str(self) -> str:
         try:
             result = to_string(self.content, self.encoding)
-            if result.encoding and result.encoding != self.encoding:
+            if self.encoding and result.encoding and result.encoding != self.encoding:
                 logger.warning(
                     f"Encoding issue, '{result.encoding}' has been used instead of "
                     f"'{self.encoding}' to decode content of '{self.orig_url_str}'"

--- a/src/warc2zim/items.py
+++ b/src/warc2zim/items.py
@@ -28,8 +28,8 @@ class WARCPayloadItem(StaticItem):
         self,
         path: str,
         record: ArcWarcRecord,
-        head_template: Template,
-        css_insert: str | None,
+        pre_head_template: Template,
+        post_head_template: Template,
         existing_zim_paths: set[ZimPath],
         missing_zim_paths: set[ZimPath] | None,
         js_modules: set[ZimPath],
@@ -40,7 +40,7 @@ class WARCPayloadItem(StaticItem):
         self.mimetype = get_record_mime_type(record)
         (self.title, self.content) = Rewriter(
             path, record, existing_zim_paths, missing_zim_paths, js_modules
-        ).rewrite(head_template, css_insert)
+        ).rewrite(pre_head_template, post_head_template)
 
     def get_hints(self):
         is_front = self.mimetype.startswith("text/html")
@@ -48,6 +48,11 @@ class WARCPayloadItem(StaticItem):
 
 
 class StaticArticle(StaticItem):
+    """A file to store in _zim_static folder, based on exisiting file.
+
+    Meant to be used for unknown mimetype which will be guessed
+    """
+
     def __init__(self, filename: Path, main_path: str, **kwargs):
         super().__init__(**kwargs)
         self.filename = filename
@@ -60,6 +65,24 @@ class StaticArticle(StaticItem):
 
     def get_path(self):
         return "_zim_static/" + self.filename.name
+
+    def get_mimetype(self):
+        return self.mime
+
+    def get_hints(self):
+        return {Hint.FRONT_ARTICLE: False}
+
+
+class StaticFile(StaticItem):
+    """A file to store in _zim_static folder, based on known content and mimetype"""
+
+    def __init__(self, content: str | bytes, filename: str, mimetype: str):
+        self.filename = filename
+        self.mime = mimetype
+        self.content = content
+
+    def get_path(self):
+        return "_zim_static/" + self.filename
 
     def get_mimetype(self):
         return self.mime

--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -652,9 +652,10 @@ class TestWarc2Zim:
         zim_output = tmp_path / zim_output
 
         res = self.get_article(zim_output, "example.com/")
-        assert b"warc2zim.kiwix.app/custom.css" in res
+        assert b"static_prefix" not in res
+        assert b"../_zim_static/custom.css" in res
 
-        res = self.get_article(zim_output, "warc2zim.kiwix.app/custom.css")
+        res = self.get_article(zim_output, "_zim_static/custom.css")
         assert custom_css == res
 
     def test_custom_css_remote(self, tmp_path):
@@ -679,9 +680,10 @@ class TestWarc2Zim:
         zim_output = tmp_path / zim_output
 
         res = self.get_article(zim_output, "example.com/")
-        assert b"warc2zim.kiwix.app/custom.css" in res
+        assert b"static_prefix" not in res
+        assert b"../_zim_static/custom.css" in res
 
-        res = self.get_article(zim_output, "warc2zim.kiwix.app/custom.css")
+        res = self.get_article(zim_output, "_zim_static/custom.css")
         assert res == requests.get(url, timeout=10).content
 
     def test_http_return_codes(self, tmp_path):


### PR DESCRIPTION
Fix #263 

Changes:
- Fix and simplify custom CSS injection
  - Pass the HTML code for CSS injection as stuff to be rendered (we need to compute the relative ZIM path based on current page location)
  - directly create a ZIM record instead of faking a WARC record (simplification and less error-prone)
  - store custom CSS at `_zim_static/custom.css` instead of magic URL `warc2zim.kiwix.app/custom.css`
- Not related to #263 but a slight enhancement of https://github.com/openzim/warc2zim/pull/260 changes: do not log issues about encoding when only concern is that no content-type was passed in HTTP headers