### PR TITLE
Validate ZIM metadata early

### DIFF
--- a/src/warc2zim/main.py
+++ b/src/warc2zim/main.py
@@ -99,6 +99,14 @@ def main(raw_args=None):
         default="fails",
     )
 
+    parser.add_argument(
+        "--disable-metadata-checks",
+        help="Disable validity checks of metadata according to openZIM conventions",
+        action="store_true",
+        default=False,
+        dest="disable_metadata_checks",
+    )
+
     args = parser.parse_args(args=raw_args)
     converter = Converter(args)
     return converter.run()

--- a/tests/test_metadata_validation.py
+++ b/tests/test_metadata_validation.py
@@ -1,0 +1,89 @@
+from itertools import chain
+
+import pytest
+
+from warc2zim.main import main
+
+
+@pytest.mark.parametrize(
+    "title, is_valid",
+    [
+        pytest.param("A title", True, id="a_valid_title"),
+        pytest.param("A very very very very long title", False, id="an_invalid_title"),
+    ],
+)
+def test_title_validation(title, is_valid):
+    args = ["--name", "test", "--title", title, "--output", "./"]
+    if is_valid:
+        assert main(args) == 100
+    else:
+        with pytest.raises(ValueError, match="Title is too long"):
+            main(args)
+
+
+@pytest.mark.parametrize(
+    "description, is_valid",
+    [
+        pytest.param("A description", True, id="a_valid_description"),
+        pytest.param(
+            "A " + "".join(["very " for i in range(20)]) + "long description",
+            False,
+            id="an_invalid_description",
+        ),
+    ],
+)
+def test_description_validation(description, is_valid):
+    args = ["--name", "test", "--description", description, "--output", "./"]
+    if is_valid:
+        assert main(args) == 100
+    else:
+        with pytest.raises(ValueError, match="Description is too long"):
+            main(args)
+
+
+@pytest.mark.parametrize(
+    "long_description, is_valid",
+    [
+        pytest.param("A long description", True, id="a_valid_long_description"),
+        pytest.param(
+            "A " + "".join(["very " for i in range(800)]) + "long description",
+            False,
+            id="an_invalid_long_description",
+        ),
+    ],
+)
+def test_long_description_validation(long_description, is_valid):
+    args = [
+        "--name",
+        "test",
+        "--long-description",
+        long_description,
+        "--output",
+        "./",
+    ]
+    if is_valid:
+        assert main(args) == 100
+    else:
+        with pytest.raises(ValueError, match="Description is too long"):
+            main(args)
+
+
+@pytest.mark.parametrize(
+    "tags, is_valid",
+    [
+        pytest.param(["tag1", "tag2"], True, id="valid_tags"),
+        # NOTA: there is no tests for invalid tags, since it is not currently possible
+    ],
+)
+def test_tags_validation(tags, is_valid):
+    args = list(
+        chain(
+            *(
+                ["--name", "test"],
+                chain(*(["--tags", tag] for tag in tags)),
+                ["--output", "./"],
+            )
+        )
+    )
+    if is_valid:
+        assert main(args) == 100


### PR DESCRIPTION
Fix #235 

Changes:
- Validate title, description, long_description and tags early, including during the pre-check call from zimit
- Add `--disable-metadata-check` CLI argument, not intended to be exposed in Zimfarm