### PR TITLE
Fix youtube thumbnails

### DIFF
--- a/rules/rules.json
+++ b/rules/rules.json
@@ -9,6 +9,10 @@
             "replace": "youtube.fuzzy.replayweb.page/\\1\\2"
         },
         {
+            "pattern": "i\\.ytimg\\.com\\/vi\\/(.*?)\\/.*?\\.(\\w*?)(?:\\?|$)",
+            "replace": "i.ytimg.com.fuzzy.replayweb.page/vi/\\1/thumbnail.\\2"
+        },
+        {
             "pattern": "([^?]+)\\?[\\d]+$",
             "replace": "\\1"
         },

--- a/tests/test_fuzzy_rules.py
+++ b/tests/test_fuzzy_rules.py
@@ -90,6 +90,39 @@ def test_fuzzyrules_google_video_infos(google_video_info_case):
 @pytest.fixture(
     params=[
         ContentForTests(
+            "i.ytimg.com/vi/-KpLmsAR23I/maxresdefault.jpg?sqp=-oaymwEmCIAKENAF8quKqQMa8"
+            "AEB-AH-CYAC0AWKAgwIABABGHIgTyg-MA8=&rs=AOn4CLDr-FmDmP3aCsD84l48ygBmkwHg-g",
+            "i.ytimg.com.fuzzy.replayweb.page/vi/-KpLmsAR23I/thumbnail.jpg",
+        ),
+        ContentForTests(
+            "i.ytimg.com/vi/-KpLmsAR23I/maxresdefault.png?sqp=-oaymwEmCIAKENAF8quKqQMa8"
+            "AEB-AH-CYAC0AWKAgwIABABGHIgTyg-MA8=&rs=AOn4CLDr-FmDmP3aCsD84l48ygBmkwHg-g",
+            "i.ytimg.com.fuzzy.replayweb.page/vi/-KpLmsAR23I/thumbnail.png",
+        ),
+        ContentForTests(
+            "i.ytimg.com/vi/-KpLmsAR23I/maxresdefault.jpg",
+            "i.ytimg.com.fuzzy.replayweb.page/vi/-KpLmsAR23I/thumbnail.jpg",
+        ),
+        ContentForTests(
+            "i.ytimg.com/vi/-KpLmsAR23I/max-res.default.jpg",
+            "i.ytimg.com.fuzzy.replayweb.page/vi/-KpLmsAR23I/thumbnail.jpg",
+        ),
+    ]
+)
+def youtube_thumbnails_case(request):
+    yield request.param
+
+
+def test_fuzzyrules_youtube_thumbnails(youtube_thumbnails_case):
+    assert (
+        apply_fuzzy_rules(youtube_thumbnails_case.input_str)
+        == youtube_thumbnails_case.expected_str
+    )
+
+
+@pytest.fixture(
+    params=[
+        ContentForTests(
             "www.example.com/page?1234",
             "www.example.com/page",
         ),


### PR DESCRIPTION
Fix #262 

Changes:
- new fuzzy rule for youtube thumbnails
  - pattern has been slightly enhanced compared to the one suggested in issue to support any file extension