### PR TITLE
Do not rewrite URLs composed of just a fragment

### DIFF
--- a/src/warc2zim/url_rewriting.py
+++ b/src/warc2zim/url_rewriting.py
@@ -275,6 +275,10 @@ class ArticleUrlRewriter:
         try:
             item_url = item_url.strip()
 
+            # Make case of standalone fragments more straightforward
+            if item_url.startswith("#"):
+                return item_url
+
             item_scheme = urlsplit(item_url).scheme
             if item_scheme and item_scheme not in ("http", "https"):
                 return item_url

--- a/test-website/content/href-to-folder/index.html
+++ b/test-website/content/href-to-folder/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Test website</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="./icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="./icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="./icons/favicon-16x16.png">
+  <link rel="manifest" href="./icons/site.webmanifest">
+  <link rel="shortcut icon" href="./icons/favicon.ico">
+</head>
+
+<body>
+
+  <h2>Tests of links to folder instead of document</h2>
+
+  <p><a href="./">./</a></p>
+  <p><a href="../href-to-folder/">../href-to-folder/</a></p>
+  <p><a href="../../href-to-folder/">../../href-to-folder/</a> (too deep)</p>
+  <p><a href="#section1">#section1</a></p>
+  <p><a href="./#section2">#section2</a></p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p id="section1">Section1</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p id="section2">Section2</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+  <p>...</p>
+
+</body>
+
+</html>

--- a/test-website/content/index.html
+++ b/test-website/content/index.html
@@ -46,6 +46,7 @@
         <li><a href="./http-return-codes.html">HTTP return codes</a></li>
         <li><a href="./base-href.html">Base href</a></li>
         <li><a href="./onxxx.html">onxxx HTML events</a></li>
+        <li><a href="./href-to-folder/">links to folder instead of file</a></li>
     </ul>
 </body>
 

--- a/tests/test_url_rewriting.py
+++ b/tests/test_url_rewriting.py
@@ -217,6 +217,27 @@ from warc2zim.url_rewriting import ArticleUrlRewriter, HttpUrl, ZimPath
             ["kiwix.org/foo.html"],
             False,
         ),
+        (
+            "https://kiwix.org/a/article/document.html",
+            "#anchor1",
+            "#anchor1",
+            ["kiwix.org/a/article/document.html"],
+            False,
+        ),
+        (
+            "https://kiwix.org/a/article/",
+            "#anchor1",
+            "#anchor1",
+            ["kiwix.org/a/article/"],
+            False,
+        ),
+        (
+            "https://kiwix.org/a/article/",
+            "../article/",
+            "./",
+            ["kiwix.org/a/article/"],
+            False,
+        ),
     ],
 )
 def test_relative_url(


### PR DESCRIPTION
Fix #277 

Changes:
- Do not statically rewrite URLs composed of just a fragment (dynamic rewrite in JS is already OK)
- Add a test case to the test website with this situation and few others around the use of a folder as last portion of the URL instead of a filename