### PR TITLE
Fix fuzzy rule for Youtube thumbnails in JS

### DIFF
--- a/javascript/test/fuzzyRules.js
+++ b/javascript/test/fuzzyRules.js
@@ -1,0 +1,35 @@
+import test from 'ava';
+
+import { applyFuzzyRules } from '../src/wombatSetup.js';
+
+test('i.ytimg.com_1', (t) => {
+  t.is(
+    applyFuzzyRules(
+      'i.ytimg.com/vi/-KpLmsAR23I/maxresdefault.jpg?sqp=-oaymwEmCIAKENAF8quKqQMa8AEB-AH-CYAC0AWKAgwIABABGHIgTyg-MA8=&rs=AOn4CLDr-FmDmP3aCsD84l48ygBmkwHg-g',
+    ),
+    'i.ytimg.com.fuzzy.replayweb.page/vi/-KpLmsAR23I/thumbnail.jpg',
+  );
+});
+
+test('i.ytimg.com_2', (t) => {
+  t.is(
+    applyFuzzyRules(
+      'i.ytimg.com/vi/-KpLmsAR23I/maxresdefault.png?sqp=-oaymwEmCIAKENAF8quKqQMa8AEB-AH-CYAC0AWKAgwIABABGHIgTyg-MA8=&rs=AOn4CLDr-FmDmP3aCsD84l48ygBmkwHg-g',
+    ),
+    'i.ytimg.com.fuzzy.replayweb.page/vi/-KpLmsAR23I/thumbnail.png',
+  );
+});
+
+test('i.ytimg.com_3', (t) => {
+  t.is(
+    applyFuzzyRules('i.ytimg.com/vi/-KpLmsAR23I/maxresdefault.jpg'),
+    'i.ytimg.com.fuzzy.replayweb.page/vi/-KpLmsAR23I/thumbnail.jpg',
+  );
+});
+
+test('i.ytimg.com_4', (t) => {
+  t.is(
+    applyFuzzyRules('i.ytimg.com/vi/-KpLmsAR23I/max-res.default.jpg'),
+    'i.ytimg.com.fuzzy.replayweb.page/vi/-KpLmsAR23I/thumbnail.jpg',
+  );
+});

--- a/rules/rules.json
+++ b/rules/rules.json
@@ -9,7 +9,7 @@
             "replace": "youtube.fuzzy.replayweb.page/\\1\\2"
         },
         {
-            "pattern": "i\\.ytimg\\.com\\/vi\\/(.*?)\\/.*?\\.(\\w*?)(?:\\?|$)",
+            "pattern": "i\\.ytimg\\.com\\/vi\\/(.*?)\\/.*?\\.(\\w*?)(?:\\?.*|$)",
             "replace": "i.ytimg.com.fuzzy.replayweb.page/vi/\\1/thumbnail.\\2"
         },
         {


### PR DESCRIPTION
While fuzzy rule is working well in Python, trailing characters after the `?` from the querystring are not removed in Javascript causing the fuzzy rewriting to be incorrect.

E.g. `'i.ytimg.com/vi/-KpLmsAR23I/maxresdefault.jpg?sqp=-oaymwEmCIAKENAF8quKqQMa8AEB-AH-CYAC0AWKAgwIABABGHIgTyg-MA8=&rs=AOn4CLDr-FmDmP3aCsD84l48ygBmkwHg-g` is transformed into `i.ytimg.com.fuzzy.replayweb.page/vi/-KpLmsAR23I/thumbnail.jpgsqp=-oaymwEmCIAKENAF8quKqQMa8AEB-AH-CYAC0AWKAgwIABABGHIgTyg-MA8=&rs=AOn4CLDr-FmDmP3aCsD84l48ygBmkwHg-g` instead of `i.ytimg.com.fuzzy.replayweb.page/vi/-KpLmsAR23I/thumbnail.jpg`

This PR fixes the situation by updating the fuzzy rules and adding a minimal test set in Javascript.

Long term solution to test all fuzzy rules in JS is described in #284 