### PR TITLE
JS URL rewriting: take into account that url might be an object

### DIFF
--- a/javascript/src/wombatSetup.js
+++ b/javascript/src/wombatSetup.js
@@ -72,6 +72,9 @@ export function urlRewriteFunction(
 ) {
   if (!url) return url;
 
+  // Transform URL which might be an object (detected on Chromium browsers at least)
+  url = String(url);
+
   // Special stuff which is not really a URI but exists in the wild
   if (['#', '{', '*'].includes(url.substring(0, 1))) return url;
 


### PR DESCRIPTION
In some occasions, url passed to JS rewriting function is an object instead of a string, causing problems like https://github.com/openzim/zim-requests/issues/1011#issuecomment-2135505415