### PR TITLE
Do not indicate to wombat that we are running inside a SW since we are not

### DIFF
--- a/javascript/src/wombatSetup.js
+++ b/javascript/src/wombatSetup.js
@@ -288,7 +288,7 @@ export function getWombatInfo(
     enable_auto_fetch: true,
     convert_post_to_get: true,
     target_frame: '___wb_replay_top_frame',
-    isSW: true,
+    isSW: false,
   };
 }
 


### PR DESCRIPTION
This is a draft PR because while it allow to solve the problem in #293, it breaks youtube videos (and probably other things)

I don't really get yet why we used to indicate to wombat that we are running inside a Service Worker since we are not.

Git history is not very clear, and this was one of the undocumented option indicated to be solved in https://github.com/openzim/warc2zim/issues/239 ; @mgautierfr do you have any explanation to share?

I tested this with all test cases from the test website and they seems to all responded positively except the Youtube video.