### PR TITLE
Drop integrity attribute in HTML `<script>` and `<link>` tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Drop `integrity` attribute in HTML `<script>` and `<link>` tags (#298)
+
 ## [2.0.0] - 2024-06-04
 
 ### Added

--- a/src/warc2zim/content_rewriting/html.py
+++ b/src/warc2zim/content_rewriting/html.py
@@ -128,6 +128,7 @@ class HtmlRewriter(HTMLParser):
             self.transform_attrs(
                 attrs,
                 self.url_rewriter_existing if tag == "a" else self.url_rewriter_all,
+                ["integrity"] if tag == "script" or "link" else [],
             )
         )
 
@@ -226,10 +227,12 @@ class HtmlRewriter(HTMLParser):
         self,
         attrs: AttrsList,
         url_rewriter: UrlRewriterProto,
+        exclude_attrs: list[str],
     ) -> str:
         processed_attrs = (
             self.process_attr(attr_name, attr_value, url_rewriter)
             for attr_name, attr_value in attrs
+            if attr_name not in exclude_attrs
         )
         return " ".join(self.format_attr(*attr) for attr in processed_attrs)
 

--- a/tests/test_html_rewriting.py
+++ b/tests/test_html_rewriting.py
@@ -185,6 +185,20 @@ def test_escaped_content(escaped_content, no_js_notify):
                 "}</script>"
             ),
         ),
+        ContentForTests(
+            '<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js"'
+            ' integrity="sha512-3gJwYpMe3QewGELv8k/BX9vcqhryRdzRMxVfq6ngyWXwo03GFEzjsUm'
+            '8Q7RZcHPHksttq7/GFoxjCVUjkjvPdw=="'
+            ' crossorigin="anonymous" referrerpolicy="no-referrer"></script>',
+            '<script src="../cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js"'
+            ' crossorigin="anonymous" referrerpolicy="no-referrer"></script>',
+        ),
+        ContentForTests(
+            '<link rel="preload" src="https://cdnjs.cloudflare.com/jquery.min.js"'
+            ' integrity="sha512-3gJwYpMe3QewGELv8k/BX9vcqhryRdzRMxVfq6ngyWXwo03GFEzjsUm'
+            '8Q7RZcHPHksttq7/GFoxjCVUjkjvPdw=="></link>',
+            '<link rel="preload" src="../cdnjs.cloudflare.com/jquery.min.js"></link>',
+        ),
     ]
 )
 def js_rewrites(request):


### PR DESCRIPTION
Fix #298 

Since the JS and CSS scripts are rewritten, integrity checks are failing on purpose. Since we do not really need these integrity checks, we just drop the attribute when rewritting the HTML.

Edit:
We do it for both <script> and <link> tags, because both are allowed to use this attribute