### PR TITLE
Add support for multiple ZIM langs + validate Language metadata

### DIFF
--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -257,7 +257,12 @@ class Converter:
             return 100
 
         self.gather_information_from_warc()
-        # validate language again, should it have been automatically retrieved from WARC
+        # Fallback language
+        if not self.language:
+            logger.warning("No valid ZIM language, fallbacking to `eng`.")
+
+            self.language = "eng"
+        # validate language definitely, could have been retrieved from WARC or fallback
         validate_language("Language", self.language)
         if not self.main_path:
             raise ValueError("Unable to find main path, aborting")

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -41,7 +41,6 @@ from zimscraperlib.constants import (
     RECOMMENDED_MAX_TITLE_LENGTH,
 )
 from zimscraperlib.download import stream_file
-from zimscraperlib.i18n import get_language_details
 from zimscraperlib.image.convertion import convert_image
 from zimscraperlib.image.transformation import resize_image
 from zimscraperlib.types import FALLBACK_MIME
@@ -55,6 +54,7 @@ from zimscraperlib.zim.metadata import (
 
 from warc2zim.constants import logger
 from warc2zim.items import StaticArticle, StaticFile, WARCPayloadItem
+from warc2zim.language import parse_language
 from warc2zim.url_rewriting import HttpUrl, ZimPath, normalize
 from warc2zim.utils import (
     can_process_status_code,
@@ -261,13 +261,8 @@ class Converter:
         self.retrieve_illustration()
         self.convert_illustration()
 
-        # make sure Language metadata is ISO-639-3
-        try:
-            lang_data = get_language_details(self.language)
-            self.language = lang_data["iso-639-3"]
-        except Exception:
-            logger.error(f"Invalid language setting `{self.language}`. Using `eng`.")
-            self.language = "eng"
+        # make sure Language metadata is valid ZIM Metadata
+        self.language = parse_language(self.language)
 
         # autoescape=False to allow injecting html entities from translated text
         self.env = Environment(

--- a/src/warc2zim/language.py
+++ b/src/warc2zim/language.py
@@ -4,10 +4,31 @@ from warc2zim.constants import logger
 
 
 def parse_language(input_lang: str) -> str:
-    """Transform the input language into a valid ZIM Language Metadata"""
-    try:
-        lang_data = get_language_details(input_lang)
-        return lang_data["iso-639-3"]
-    except Exception:
-        logger.error(f"Invalid language setting `{input_lang}`. Using `eng`.")
-        return "eng"
+    """Transform the input language into a valid ZIM Language Metadata
+
+    Support many ways to describe the language (all ISO 639 + English label)
+    Supports a comma-separated list of languages as input.
+    Deduplicates languages.
+    Ignore whitespaces.
+    Preserve language ordering (since it conveys meaning in ZIM metadata).
+    """
+
+    langs = []  # use a list to preserve order
+
+    for lang in [lang.strip() for lang in input_lang.split(",")]:
+        try:
+            lang_data = get_language_details(lang)
+            parsed_lang = lang_data["iso-639-3"]
+            if parsed_lang not in langs:
+                langs.append(parsed_lang)
+        except Exception:
+            logger.warning(f"Skipping invalid language setting `{lang}`.")
+            continue  # skip unrecognized
+
+    if len(langs) == 0:
+        logger.warning(
+            f"No valid language found in `{input_lang}`, fallbacking to `eng`."
+        )
+        return "eng"  # Fallback value should we not have detected a lang
+
+    return ",".join(langs)

--- a/src/warc2zim/language.py
+++ b/src/warc2zim/language.py
@@ -1,0 +1,13 @@
+from zimscraperlib.i18n import get_language_details
+
+from warc2zim.constants import logger
+
+
+def parse_language(input_lang: str) -> str:
+    """Transform the input language into a valid ZIM Language Metadata"""
+    try:
+        lang_data = get_language_details(input_lang)
+        return lang_data["iso-639-3"]
+    except Exception:
+        logger.error(f"Invalid language setting `{input_lang}`. Using `eng`.")
+        return "eng"

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -15,6 +15,12 @@ from warc2zim.language import parse_language
         pytest.param("Chinese", "zho", id="chinese_full_1"),
         pytest.param("chinEse", "zho", id="chinese_full_2"),
         pytest.param("patois", "eng", id="unrecognized_bad_name"),
+        pytest.param("unknown,fra,unknown", "fra", id="ignore_unknown"),
+        pytest.param("eng,fra", "eng,fra", id="two_langs_1"),
+        pytest.param("fra,eng", "fra,eng", id="two_langs_2"),  # order must be preserved
+        pytest.param("  eng ,   fra    ", "eng,fra", id="two_langs_spaces"),
+        pytest.param("eng,fra,English", "eng,fra", id="duplicates"),
+        pytest.param("eng;fra", "eng", id="unrecognized_bad_separator"),
     ],
 )
 def test_parse_language(input_lang, expected_lang):

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,0 +1,21 @@
+import pytest
+
+from warc2zim.language import parse_language
+
+
+@pytest.mark.parametrize(
+    "input_lang, expected_lang",
+    [
+        pytest.param("en", "eng", id="english_2_chars"),
+        pytest.param("eng", "eng", id="english_3_chars"),
+        pytest.param("English", "eng", id="english_full_1"),
+        pytest.param("zh", "zho", id="chinese_2_chars"),
+        pytest.param("zh-hans", "zho", id="chinese_variant"),
+        pytest.param("zho", "zho", id="chinese_3_chars"),
+        pytest.param("Chinese", "zho", id="chinese_full_1"),
+        pytest.param("chinEse", "zho", id="chinese_full_2"),
+        pytest.param("patois", "eng", id="unrecognized_bad_name"),
+    ],
+)
+def test_parse_language(input_lang, expected_lang):
+    assert parse_language(input_lang) == expected_lang


### PR DESCRIPTION
Fix #300 

Changes:
- isolate method to parse language received either from input (CLI) args or automatically retrieved from HTML metadata
- add unit testing on this method
- add support for a list of languages, permissive to spaces which will be trimmed and preserving list of languages order
- add validation of language metadata, including early validation if the lang comes from input (CLI) args
- add a real fallback to `eng` as indicated in usage, wasn't done when no lang was provided at CLI and no lang was found in WARC records