### PR TITLE
Use mimetype to selectively rewrite only html documents

### DIFF
--- a/src/warc2zim/content_rewriting/generic.py
+++ b/src/warc2zim/content_rewriting/generic.py
@@ -152,7 +152,7 @@ class Rewriter:
     def get_resourcetype_rewrite_mode(self, record, resourcetype, mimetype):
         """Get current record rewrite mode based on WARC-Resource-Type and mimetype"""
 
-        if resourcetype == "document":
+        if resourcetype == "document" and mimetype == "text/html":
             # TODO : Handle header "Accept" == "application/json"
             if getattr(record, "method", "GET") == "GET":
                 return "html"


### PR DESCRIPTION
Fix #313 

Nota: there is no additional test because I failed to reproduce the issue with the crawler. In general, PDFs are retrieved with Direct Fetch by the crawler, and in such a case we do not have the `WARC-Resource-Type` header. 

This also explains why I did not encountered this situation during my tests before 2.0.1 release. 

Under some condition Direct Fetch is not used by the crawler ... and we obviously encountered the situtation in production.