### PR TITLE
Add option to ignore charsets found automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--ignore-content-header-charsets` option to disable automatic retrieval of content charsets from content first bytes (#318)
+- Add `--ignore-http-header-charsets` option to disable automatic retrieval of content charsets from content HTTP `Content-Type` headers (#318)
+
 ## [2.0.1] - 2024-06-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--ignore-content-header-charsets` option to disable automatic retrieval of content charsets from content first bytes (#318)
 - Add `--ignore-http-header-charsets` option to disable automatic retrieval of content charsets from content HTTP `Content-Type` headers (#318)
 
+### Changed
+
+- Simplify logic deciding content charset, stop guessing with chardet (#312)
+
+### Fixed
+
+- Rewrite only content with mimetype `text-html` when `WARC-Resource-Type` is `html` (#313)
+
 ## [2.0.1] - 2024-06-13
 
 ### Added

--- a/src/warc2zim/content_rewriting/generic.py
+++ b/src/warc2zim/content_rewriting/generic.py
@@ -64,6 +64,9 @@ class Rewriter:
         missing_zim_paths: set[ZimPath] | None,
         js_modules: set[ZimPath],
         charsets_to_try: list[str],
+        *,
+        ignore_content_header_charsets: bool,
+        ignore_http_header_charsets: bool,
     ):
         self.content = get_record_content(record)
 
@@ -80,10 +83,18 @@ class Rewriter:
         self.rewrite_mode = self.get_rewrite_mode(record, mimetype)
         self.js_modules = js_modules
         self.charsets_to_try = charsets_to_try
+        self.ignore_content_header_charsets = ignore_content_header_charsets
+        self.ignore_http_header_charsets = ignore_http_header_charsets
 
     @property
     def content_str(self) -> str:
-        return to_string(self.content, self.encoding, self.charsets_to_try)
+        return to_string(
+            self.content,
+            self.encoding,
+            self.charsets_to_try,
+            ignore_content_header_charsets=self.ignore_content_header_charsets,
+            ignore_http_header_charsets=self.ignore_http_header_charsets,
+        )
 
     def rewrite(
         self, pre_head_template: Template, post_head_template: Template

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -209,6 +209,8 @@ class Converter:
 
         self.continue_on_error = bool(args.continue_on_error)
         self.disable_metadata_checks = bool(args.disable_metadata_checks)
+        self.ignore_content_header_charsets = bool(args.ignore_content_header_charsets)
+        self.ignore_http_header_charsets = bool(args.ignore_http_header_charsets)
 
     def update_stats(self):
         """write progress as JSON to self.stats_filename if requested"""
@@ -751,6 +753,8 @@ class Converter:
                 self.missing_zim_paths,
                 self.js_modules,
                 self.charsets_to_try,
+                ignore_content_header_charsets=self.ignore_content_header_charsets,
+                ignore_http_header_charsets=self.ignore_http_header_charsets,
             )
 
             if len(payload_item.content) != 0:

--- a/src/warc2zim/items.py
+++ b/src/warc2zim/items.py
@@ -34,6 +34,9 @@ class WARCPayloadItem(StaticItem):
         missing_zim_paths: set[ZimPath] | None,
         js_modules: set[ZimPath],
         charsets_to_try: list[str],
+        *,
+        ignore_content_header_charsets: bool,
+        ignore_http_header_charsets: bool,
     ):
         super().__init__()
 
@@ -46,6 +49,8 @@ class WARCPayloadItem(StaticItem):
             missing_zim_paths,
             js_modules,
             charsets_to_try,
+            ignore_content_header_charsets=ignore_content_header_charsets,
+            ignore_http_header_charsets=ignore_http_header_charsets,
         ).rewrite(pre_head_template, post_head_template)
 
     def get_hints(self):

--- a/src/warc2zim/main.py
+++ b/src/warc2zim/main.py
@@ -118,6 +118,22 @@ def main(raw_args=None):
         default="UTF-8,ISO-8859-1",
     )
 
+    parser.add_argument(
+        "--ignore-content-header-charsets",
+        help="Ignore the charsets specified in content headers - first bytes - "
+        "typically because they are wrong",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--ignore-http-header-charsets",
+        help="Ignore the charsets specified in HTTP `Content-Type` headers, typically "
+        "because they are wrong",
+        action="store_true",
+        default=False,
+    )
+
     args = parser.parse_args(args=raw_args)
     converter = Converter(args)
     return converter.run()

--- a/tests/test_rewriting.py
+++ b/tests/test_rewriting.py
@@ -39,6 +39,8 @@ def rewrite_generator():
             set(),
             set(),
             ["UTF-8", "ISO-8859-1"],
+            ignore_http_header_charsets=False,
+            ignore_content_header_charsets=False,
         ).rewrite(Template(""), Template(""))
 
     yield generate_and_call


### PR DESCRIPTION
Fix #318 

Changes:
- add the two options mentioned in issue and use them to ignore automatically detected charsets
- add missing CHANGELOG entries from previous PRs

