### PR TITLE
Document wombat settings and change wombat mode to fix major issue of MDN ZIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to wombat 3.8.4 (#334)
+- Fix wombat setup settings (especially `isSW`) (#293)
+
 ## [2.1.3] - 2024-11-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade to wombat 3.8.4 (#334)
+- Upgrade to wombat 3.8.6 (#334)
 - Fix wombat setup settings (especially `isSW`) (#293)
 
 ## [2.1.3] - 2024-11-01

--- a/javascript/src/wombatSetup.js
+++ b/javascript/src/wombatSetup.js
@@ -288,14 +288,21 @@ export function getWombatInfo(
     // The host of the original url
     wombat_host: orig_host,
 
-    // Extra options ?
-    wombat_opts: {},
+    // We are not running inside a service worker, wombat needs to know about it since
+    // some "magic" URLs like blobs are not available
+    isSW: false,
 
-    // ?
-    enable_auto_fetch: true,
+    // Convert all post request to get request
     convert_post_to_get: true,
+
+    // Not used, we are not replaying in a frame
     target_frame: '___wb_replay_top_frame',
-    isSW: true,
+
+    // Not used, we are not running in live mode
+    enable_auto_fetch: false,
+
+    // Extra options, not used
+    wombat_opts: {},
   };
 }
 

--- a/javascript/test/wombatSetup.js
+++ b/javascript/test/wombatSetup.js
@@ -21,8 +21,8 @@ test('nominalWbInfo', (t) => {
   );
   t.is(wmInfo.coll, '');
   t.is(wmInfo.convert_post_to_get, true);
-  t.is(wmInfo.enable_auto_fetch, true);
-  t.is(wmInfo.isSW, true);
+  t.is(wmInfo.enable_auto_fetch, false);
+  t.is(wmInfo.isSW, false);
   t.is(wmInfo.is_framed, false);
   t.is(wmInfo.is_live, false);
   t.is(wmInfo.mod, '');

--- a/openzim.toml
+++ b/openzim.toml
@@ -6,7 +6,7 @@ execute_after=[
 
 [files.assets.actions."wombat.js"]
 action="get_file"
-source="https://cdn.jsdelivr.net/npm/@webrecorder/wombat@3.8.4/dist/wombat.js"
+source="https://cdn.jsdelivr.net/npm/@webrecorder/wombat@3.8.6/dist/wombat.js"
 target_file="wombat.js"
 
 [files.assets.actions."wombatSetup.js"] # fallback if this script has not been properly build (should happen only in dev)

--- a/openzim.toml
+++ b/openzim.toml
@@ -6,7 +6,7 @@ execute_after=[
 
 [files.assets.actions."wombat.js"]
 action="get_file"
-source="https://cdn.jsdelivr.net/npm/@webrecorder/wombat@3.8.3/dist/wombat.js"
+source="https://cdn.jsdelivr.net/npm/@webrecorder/wombat@3.8.4/dist/wombat.js"
 target_file="wombat.js"
 
 [files.assets.actions."wombatSetup.js"] # fallback if this script has not been properly build (should happen only in dev)


### PR DESCRIPTION
Fix #293 
Fix #239 
Fix #333 

Changes:
- `isSW` is set to `false`, as recommended by Ilya in https://github.com/webrecorder/wombat/issues/155#issuecomment-2183191941
- `enable_auto_fetch` is set to `false` (not used anyway in our use of wombat, but setting this to `true` is a bit misleading)
- upgrade wombat to 3.8.6

~~Main concern with merging this is that this breaks the Youtube player, so we should probably wait for a solution to #333~~ => solved in wombat 3.8.4 which is part of this PR

~~Other concern is that is #327 is still not solved by this PR~~ => this is a distinct and way more tricky problem, especially in terms of implementation