### PR TITLE
Refactor HTML rewriter class to make it more open to change and expressive

### DIFF
--- a/src/warc2zim/content_rewriting/__init__.py
+++ b/src/warc2zim/content_rewriting/__init__.py
@@ -1,3 +1,0 @@
-from collections.abc import Callable
-
-UrlRewriterProto = Callable[[str], str]

--- a/src/warc2zim/content_rewriting/html.py
+++ b/src/warc2zim/content_rewriting/html.py
@@ -1,22 +1,69 @@
 import io
 from collections import namedtuple
 from collections.abc import Callable
-from functools import partial
+from dataclasses import dataclass
 from html import escape
 from html.parser import HTMLParser
+from inspect import signature
 
 from bs4 import BeautifulSoup
 
-from warc2zim.content_rewriting import UrlRewriterProto
 from warc2zim.content_rewriting.css import CssRewriter
 from warc2zim.content_rewriting.ds import get_ds_rules
 from warc2zim.content_rewriting.js import JsRewriter
 from warc2zim.content_rewriting.rx_replacer import RxRewriter
 from warc2zim.url_rewriting import ArticleUrlRewriter, ZimPath
 
-AttrsList = list[tuple[str, str | None]]
+AttrNameAndValue = tuple[str, str | None]
+AttrsList = list[AttrNameAndValue]
 
 RewritenHtml = namedtuple("RewritenHmtl", ["title", "content"])
+
+
+def get_attr_value_from(
+    attrs: AttrsList, name: str, default: str | None = None
+) -> str | None:
+    """Get one HTML attribute value if present, else return default value"""
+    for attr_name, value in attrs:
+        if attr_name == name:
+            return value
+    return default
+
+
+def format_attr(name: str, value: str | None) -> str:
+    """Format a given attribute name and value, properly escaping the value"""
+    if value is None:
+        return name
+    html_escaped_value = escape(value, quote=True)
+    return f'{name}="{html_escaped_value}"'
+
+
+def get_html_rewrite_context(tag: str, attrs: AttrsList) -> str:
+    """Get current HTML rewrite context
+
+    By default, rewrite context is the HTML tag. But in some cases (e.g. script tags) we
+    need to be more precise since rewriting logic will vary based on another attribute
+    value (e.g. type attribute for script tags)
+    """
+    if tag == "script":
+        script_type = get_attr_value_from(attrs, "type")
+        return {
+            "application/json": "json",
+            "json": "json",
+            "module": "js-module",
+            "application/javascript": "js-classic",
+            "text/javascript": "js-classic",
+            "": "js-classic",
+        }.get(script_type or "", "unknown")
+    elif tag == "link":
+        link_rel = get_attr_value_from(attrs, "rel")
+        if link_rel == "modulepreload":
+            return "js-module"
+        elif link_rel == "preload":
+            preload_type = get_attr_value_from(attrs, "as")
+            if preload_type == "script":
+                return "js-classic"
+    return tag
 
 
 def extract_base_href(content: str) -> str | None:
@@ -60,12 +107,6 @@ class HtmlRewriter(HTMLParser):
         self.output = io.StringIO()
 
         self.base_href = extract_base_href(content)
-        self.url_rewriter_all = partial(
-            self.url_rewriter, base_href=self.base_href, rewrite_all_url=True
-        )
-        self.url_rewriter_existing = partial(
-            self.url_rewriter, base_href=self.base_href, rewrite_all_url=False
-        )
         self.css_rewriter = CssRewriter(self.url_rewriter, self.base_href)
         self.js_rewriter = JsRewriter(
             url_rewriter=self.url_rewriter,
@@ -85,60 +126,39 @@ class HtmlRewriter(HTMLParser):
         self.output.write(value)  # pyright: ignore[reportOptionalMemberAccess]
 
     def handle_starttag(self, tag: str, attrs: AttrsList, *, auto_close: bool = False):
-        self.html_rewrite_context = tag  # default value if not overriden later on
-        if tag == "script":
-            script_type = self.extract_attr(attrs, "type")
-            self.html_rewrite_context = {
-                "application/json": "json",
-                "json": "json",
-                "module": "js-module",
-                "application/javascript": "js-classic",
-                "text/javascript": "js-classic",
-                "": "js-classic",
-            }.get(script_type or "", "unknown")
-        elif tag == "link":
-            link_rel = self.extract_attr(attrs, "rel")
-            if link_rel == "modulepreload":
-                self.html_rewrite_context = "js-module"
-            elif link_rel == "preload":
-                preload_type = self.extract_attr(attrs, "as")
-                if preload_type == "script":
-                    self.html_rewrite_context = "js-classic"
+        self.html_rewrite_context = get_html_rewrite_context(tag=tag, attrs=attrs)
 
-        # Handle special case of <base> tag which have to be simplified (remove href)
-        # and hence write only if not empty
-        if tag == "base":
-            values = " ".join(
-                self.format_attr(*attr)
-                for attr in [
-                    (attr_name, attr_value)
-                    for (attr_name, attr_value) in attrs
-                    if attr_name != "href"
-                ]
+        if (
+            rewritten := rules._do_tag_rewrite(
+                tag=tag, attrs=attrs, auto_close=auto_close
             )
-            if values:
-                self.send(f"<base {values}>")
-                self.base_written = True
+        ) is not None:
+            self.send(rewritten)
             return
 
         self.send(f"<{tag}")
         if attrs:
             self.send(" ")
         self.send(
-            self.transform_attrs(
-                attrs,
-                self.url_rewriter_existing if tag == "a" else self.url_rewriter_all,
-                ["integrity"] if tag == "script" or "link" else [],
-                rewrite_content_attr=(
-                    tag == "meta"
-                    and any(
-                        attr_name.lower() == "http-equiv"
-                        and attr_value
-                        and attr_value.lower() == "content-type"
-                        for (attr_name, attr_value) in attrs
+            " ".join(
+                format_attr(*attr)
+                for attr in (
+                    rules._do_attribute_rewrite(
+                        tag=tag,
+                        attr_name=attr_name,
+                        attr_value=attr_value,
+                        attrs=attrs,
+                        js_rewriter=self.js_rewriter,
+                        css_rewriter=self.css_rewriter,
+                        url_rewriter=self.url_rewriter,
+                        base_href=self.base_href,
+                        notify_js_module=self.notify_js_module,
                     )
-                ),
-                rewrite_charset_attr=(tag == "meta"),
+                    for attr_name, attr_value in attrs
+                    if not rules._do_drop_attribute(
+                        tag=tag, attr_name=attr_name, attr_value=attr_value, attrs=attrs
+                    )
+                )
             )
         )
 
@@ -162,19 +182,21 @@ class HtmlRewriter(HTMLParser):
     def handle_data(self, data: str):
         if self.html_rewrite_context == "title" and self.title is None:
             self.title = data.strip()
-        elif self.html_rewrite_context == "style":
-            data = self.css_rewriter.rewrite(data)
-        elif self.html_rewrite_context == "json":
-            if data.strip():
-                rules = get_ds_rules(self.url_rewriter.article_url.value)
-                if rules:
-                    data = RxRewriter(rules).rewrite(data, {})
-        elif self.html_rewrite_context and self.html_rewrite_context.startswith("js-"):
-            if data.strip():
-                data = self.js_rewriter.rewrite(
-                    data,
-                    opts={"isModule": self.html_rewrite_context == "js-module"},
+        if (
+            data.strip()
+            and (
+                rewritten := rules._do_data_rewrite(
+                    html_rewrite_context=self.html_rewrite_context,
+                    data=data,
+                    css_rewriter=self.css_rewriter,
+                    js_rewriter=self.js_rewriter,
+                    url_rewriter=self.url_rewriter,
                 )
+            )
+            is not None
+        ):
+            self.send(rewritten)
+            return
         self.send(data)
 
     def handle_entityref(self, name: str):
@@ -195,81 +217,412 @@ class HtmlRewriter(HTMLParser):
     def unknown_decl(self, data: str):
         self.handle_decl(data)
 
-    def process_attr(
+
+DropAttributeCallable = Callable[..., bool]
+RewriteAttributeCallable = Callable[..., AttrNameAndValue | None]
+RewriteTagCallable = Callable[..., str | None]
+RewriteDataCallable = Callable[..., str | None]
+
+
+@dataclass(frozen=True)
+class DropAttributeRule:
+    """A rule specifying when an HTML attribute should be dropped"""
+
+    func: DropAttributeCallable
+
+
+@dataclass(frozen=True)
+class RewriteAttributeRule:
+    """A rule specifying how a given HTML attribute should be rewritten"""
+
+    func: RewriteAttributeCallable
+
+
+@dataclass(frozen=True)
+class RewriteTagRule:
+    """A rule specifying how a given HTML tag should be rewritten"""
+
+    func: RewriteTagCallable
+
+
+@dataclass(frozen=True)
+class RewriteDataRule:
+    """A rule specifying how a given HTML data should be rewritten"""
+
+    func: RewriteDataCallable
+
+
+def _check_decorated_func_signature(expected_func: Callable, decorated_func: Callable):
+    """Checks if the decorated function signature is compatible
+
+    It checks that decorated function parameters have known names and proper types
+    """
+    expected_params = signature(expected_func).parameters
+    func_params = signature(decorated_func).parameters
+    for name, param in func_params.items():
+        if name not in expected_params:
+            raise TypeError(
+                f"Parameter '{name}' is unsupported in function "
+                f"'{decorated_func.__name__}'"
+            )
+
+        if expected_params[name].annotation != param.annotation:
+            raise TypeError(
+                f"Parameter '{name}' in function '{decorated_func.__name__}' must be of"
+                f" type '{expected_params[name].annotation}'"
+            )
+
+
+class HTMLRewritingRules:
+    """A class holding the definitions of all rules to rewrite HTML documents"""
+
+    def __init__(self) -> None:
+        self.drop_attribute_rules: set[DropAttributeRule] = set()
+        self.rewrite_attribute_rules: set[RewriteAttributeRule] = set()
+        self.rewrite_tag_rules: set[RewriteTagRule] = set()
+        self.rewrite_data_rules: set[RewriteDataRule] = set()
+
+    def drop_attribute(
         self,
+    ) -> Callable[[DropAttributeCallable], DropAttributeCallable]:
+        """Decorator to use when defining a rule regarding attribute dropping"""
+
+        def decorator(func: DropAttributeCallable) -> DropAttributeCallable:
+            _check_decorated_func_signature(self._do_drop_attribute, func)
+            self.drop_attribute_rules.add(DropAttributeRule(func=func))
+            return func
+
+        return decorator
+
+    def rewrite_attribute(
+        self,
+    ) -> Callable[[RewriteAttributeCallable], RewriteAttributeCallable]:
+        """Decorator to use when defining a rule regarding attribute rewriting"""
+
+        def decorator(func: RewriteAttributeCallable) -> RewriteAttributeCallable:
+            _check_decorated_func_signature(self._do_attribute_rewrite, func)
+            self.rewrite_attribute_rules.add(RewriteAttributeRule(func=func))
+            return func
+
+        return decorator
+
+    def rewrite_tag(
+        self,
+    ) -> Callable[[RewriteTagCallable], RewriteTagCallable]:
+        """Decorator to use when defining a rule regarding tag rewriting
+
+        This has to be used when we need to rewrite the whole start tag. It can also
+        handle rewrites of startend tags (autoclosing tags).
+        """
+
+        def decorator(func: RewriteTagCallable) -> RewriteTagCallable:
+            _check_decorated_func_signature(self._do_tag_rewrite, func)
+            self.rewrite_tag_rules.add(RewriteTagRule(func=func))
+            return func
+
+        return decorator
+
+    def rewrite_data(
+        self,
+    ) -> Callable[[RewriteDataCallable], RewriteDataCallable]:
+        """Decorator to use when defining a rule regarding data rewriting
+
+        This has to be used when we need to rewrite the tag data.
+        """
+
+        def decorator(func: RewriteDataCallable) -> RewriteDataCallable:
+            _check_decorated_func_signature(self._do_data_rewrite, func)
+            self.rewrite_data_rules.add(RewriteDataRule(func=func))
+            return func
+
+        return decorator
+
+    def _do_drop_attribute(
+        self, tag: str, attr_name: str, attr_value: str | None, attrs: AttrsList
+    ) -> bool:
+        """Utility function to process all attribute dropping rules
+
+        Returns true if at least one rule is matching
+        """
+        return any(
+            rule.func(
+                **{
+                    arg_name: arg_value
+                    for arg_name, arg_value in {
+                        "tag": tag,
+                        "attr_name": attr_name,
+                        "attr_value": attr_value,
+                        "attrs": attrs,
+                    }.items()
+                    if arg_name in signature(rule.func).parameters
+                }
+            )
+            is True
+            for rule in self.drop_attribute_rules
+        )
+
+    def _do_attribute_rewrite(
+        self,
+        tag: str,
         attr_name: str,
         attr_value: str | None,
-        url_rewriter: UrlRewriterProto,
-        *,
-        rewrite_content_attr: bool,
-        rewrite_charset_attr: bool,
-    ) -> tuple[str, str | None]:
-        if not attr_value:
-            return (attr_name, attr_value)
-
-        if attr_name in ("href", "src"):
-            if self.html_rewrite_context == "js-module":
-                self.notify_js_module(
-                    self.url_rewriter.get_item_path(
-                        attr_value, base_href=self.base_href
-                    )
-                )
-            return (attr_name, url_rewriter(attr_value))
-        if attr_name == "srcset":
-            value_list = attr_value.split(",")
-            new_value_list = []
-            for value in value_list:
-                url, *other = value.strip().split(" ", maxsplit=1)
-                new_url = url_rewriter(url)
-                new_value = " ".join([new_url, *other])
-                new_value_list.append(new_value)
-            return (attr_name, ", ".join(new_value_list))
-        if attr_name == "style":
-            return (attr_name, self.css_rewriter.rewrite_inline(attr_value))
-        if attr_name.startswith("on") and not attr_name.startswith("on-"):
-            return (attr_name, self.js_rewriter.rewrite(attr_value))
-        if attr_name == "content" and rewrite_content_attr:
-            # rewrite <meta http-equiv="Content-Type" content="text/html; charset=xx" />
-            # inside ZIM, charset is always UTF-8
-            return (attr_name, "text/html; charset=UTF-8")
-        if attr_name == "charset" and rewrite_charset_attr:
-            # rewrite <meta charset="xx" />
-            # inside ZIM, charset is always UTF-8
-            return (attr_name, "UTF-8")
-        return (attr_name, attr_value)
-
-    def format_attr(self, name: str, value: str | None) -> str:
-        if value is None:
-            return name
-        html_escaped_value = escape(value, quote=True)
-        return f'{name}="{html_escaped_value}"'
-
-    def transform_attrs(
-        self,
         attrs: AttrsList,
-        url_rewriter: UrlRewriterProto,
-        exclude_attrs: list[str],
-        *,
-        rewrite_content_attr: bool,
-        rewrite_charset_attr: bool,
-    ) -> str:
-        processed_attrs = (
-            self.process_attr(
-                attr_name,
-                attr_value,
-                url_rewriter,
-                rewrite_content_attr=rewrite_content_attr,
-                rewrite_charset_attr=rewrite_charset_attr,
-            )
-            for attr_name, attr_value in attrs
-            if attr_name not in exclude_attrs
-        )
-        return " ".join(self.format_attr(*attr) for attr in processed_attrs)
+        js_rewriter: JsRewriter,
+        css_rewriter: CssRewriter,
+        url_rewriter: ArticleUrlRewriter,
+        base_href: str | None,
+        notify_js_module: Callable[[ZimPath], None],
+    ) -> AttrNameAndValue:
+        """Utility function to process all attribute rewriting rules
 
-    def extract_attr(
-        self, attrs: AttrsList, name: str, default: str | None = None
+        Returns the rewritten attribute name and value
+        """
+
+        if attr_value is None:
+            return attr_name, None
+
+        for rule in self.rewrite_attribute_rules:
+            if (
+                rewritten := rule.func(
+                    **{
+                        arg_name: arg_value
+                        for arg_name, arg_value in {
+                            "tag": tag,
+                            "attr_name": attr_name,
+                            "attr_value": attr_value,
+                            "attrs": attrs,
+                            "js_rewriter": js_rewriter,
+                            "css_rewriter": css_rewriter,
+                            "url_rewriter": url_rewriter,
+                            "base_href": base_href,
+                            "notify_js_module": notify_js_module,
+                        }.items()
+                        if arg_name in signature(rule.func).parameters
+                    }
+                )
+            ) is not None:
+                attr_name, attr_value = rewritten
+
+        return attr_name, attr_value
+
+    def _do_tag_rewrite(
+        self,
+        tag: str,
+        attrs: AttrsList,
+        *,
+        auto_close: bool,
     ) -> str | None:
-        for attr_name, value in attrs:
-            if attr_name == name:
-                return value
-        return default
+        """Utility function to process all tag rewriting rules
+
+        Returns the rewritten tag
+        """
+
+        for rule in self.rewrite_tag_rules:
+            if (
+                rewritten := rule.func(
+                    **{
+                        arg_name: arg_value
+                        for arg_name, arg_value in {
+                            "tag": tag,
+                            "attrs": attrs,
+                            "auto_close": auto_close,
+                        }.items()
+                        if arg_name in signature(rule.func).parameters
+                    }
+                )
+            ) is not None:
+                return rewritten
+
+    def _do_data_rewrite(
+        self,
+        html_rewrite_context: str | None,
+        data: str,
+        css_rewriter: CssRewriter,
+        js_rewriter: JsRewriter,
+        url_rewriter: ArticleUrlRewriter,
+    ) -> str | None:
+        """Utility function to process all data rewriting rules
+
+        Returns the rewritten data
+        """
+
+        for rule in self.rewrite_data_rules:
+            if (
+                rewritten := rule.func(
+                    **{
+                        arg_name: arg_value
+                        for arg_name, arg_value in {
+                            "html_rewrite_context": html_rewrite_context,
+                            "data": data,
+                            "css_rewriter": css_rewriter,
+                            "js_rewriter": js_rewriter,
+                            "url_rewriter": url_rewriter,
+                        }.items()
+                        if arg_name in signature(rule.func).parameters
+                    }
+                )
+            ) is not None:
+                return rewritten
+
+
+rules = HTMLRewritingRules()
+
+
+@rules.drop_attribute()
+def drop_script_integrity_attribute(tag: str, attr_name: str):
+    """Drop integrity attribute in <script> tags"""
+    return tag == "script" and attr_name == "integrity"
+
+
+@rules.drop_attribute()
+def drop_link_integrity_attribute(tag: str, attr_name: str):
+    """Drop integrity attribute in <link> tags"""
+    return tag == "link" and attr_name == "integrity"
+
+
+@rules.rewrite_attribute()
+def rewrite_meta_charset_content(
+    tag: str, attr_name: str, attrs: AttrsList
+) -> AttrNameAndValue | None:
+    """Rewrite charset indicated in meta tag
+
+    We need to rewrite both <meta charset='xxx'> and
+    <meta http-equiv='content-type' content='text/html; charset=xxx'>
+    """
+    if tag != "meta":
+        return
+    if attr_name == "charset":
+        return (attr_name, "UTF-8")
+    if attr_name == "content" and any(
+        attr_name.lower() == "http-equiv"
+        and attr_value
+        and attr_value.lower() == "content-type"
+        for attr_name, attr_value in attrs
+    ):
+        return (attr_name, "text/html; charset=UTF-8")
+
+
+@rules.rewrite_attribute()
+def rewrite_onxxx_tags(
+    attr_name: str, attr_value: str | None, js_rewriter: JsRewriter
+) -> AttrNameAndValue | None:
+    """Rewrite onxxx script attributes"""
+    if attr_value and attr_name.startswith("on") and not attr_name.startswith("on-"):
+        return (attr_name, js_rewriter.rewrite(attr_value))
+
+
+@rules.rewrite_attribute()
+def rewrite_style_tags(
+    attr_name: str, attr_value: str | None, css_rewriter: CssRewriter
+) -> AttrNameAndValue | None:
+    """Rewrite style attributes"""
+    if attr_value and attr_name == "style":
+        return (attr_name, css_rewriter.rewrite_inline(attr_value))
+
+
+@rules.rewrite_attribute()
+def rewrite_href_src_attributes(
+    tag: str,
+    attr_name: str,
+    attr_value: str | None,
+    attrs: AttrsList,
+    url_rewriter: ArticleUrlRewriter,
+    base_href: str | None,
+    notify_js_module: Callable[[ZimPath], None],
+):
+    """Rewrite href and src attributes
+
+    This is also notifying of any JS script found used as a module, so that this script
+    is properly rewritten when encountered later on.
+    """
+    if attr_name not in ("href", "src") or not attr_value:
+        return
+    if get_html_rewrite_context(tag=tag, attrs=attrs) == "js-module":
+        notify_js_module(url_rewriter.get_item_path(attr_value, base_href=base_href))
+    return (
+        attr_name,
+        url_rewriter(attr_value, base_href=base_href, rewrite_all_url=tag != "a"),
+    )
+
+
+@rules.rewrite_attribute()
+def rewrite_srcset_attribute(
+    attr_name: str,
+    attr_value: str | None,
+    url_rewriter: ArticleUrlRewriter,
+    base_href: str | None,
+):
+    """Rewrite srcset attributes"""
+    if attr_name != "srcset" or not attr_value:
+        return
+    value_list = attr_value.split(",")
+    new_value_list = []
+    for value in value_list:
+        url, *other = value.strip().split(" ", maxsplit=1)
+        new_url = url_rewriter(url, base_href=base_href)
+        new_value = " ".join([new_url, *other])
+        new_value_list.append(new_value)
+    return (attr_name, ", ".join(new_value_list))
+
+
+@rules.rewrite_tag()
+def rewrite_base_tag(tag: str, attrs: AttrsList, *, auto_close: bool):
+    """Handle special case of <base> tag which have to be simplified (remove href)
+
+    This is special because resulting tag might be empty and hence needs to be dropped
+    """
+    if tag != "base":
+        return
+    if get_attr_value_from(attrs, "href") is None:
+        return  # needed so that other rules will be processed as well
+    values = " ".join(
+        format_attr(*attr)
+        for attr in [
+            (attr_name, attr_value)
+            for (attr_name, attr_value) in attrs
+            if attr_name != "href"
+        ]
+    )
+    if values:
+        return f"<base {values}{'/>' if auto_close else '>'}"
+    else:
+        return ""  # drop whole tag
+
+
+@rules.rewrite_data()
+def rewrite_css_data(
+    html_rewrite_context: str | None, data: str, css_rewriter: CssRewriter
+) -> str | None:
+    """Rewrite inline CSS"""
+    if html_rewrite_context != "style":
+        return
+    return css_rewriter.rewrite(data)
+
+
+@rules.rewrite_data()
+def rewrite_json_data(
+    html_rewrite_context: str | None,
+    data: str,
+    url_rewriter: ArticleUrlRewriter,
+) -> str | None:
+    """Rewrite inline JSON"""
+    if html_rewrite_context != "json":
+        return
+    rules = get_ds_rules(url_rewriter.article_url.value)
+    if rules:
+        data = RxRewriter(rules).rewrite(data, {})
+
+
+@rules.rewrite_data()
+def rewrite_js_data(
+    html_rewrite_context: str | None,
+    data: str,
+    js_rewriter: JsRewriter,
+) -> str | None:
+    """Rewrite inline JS"""
+    if not (html_rewrite_context and html_rewrite_context.startswith("js-")):
+        return
+    return js_rewriter.rewrite(
+        data,
+        opts={"isModule": html_rewrite_context == "js-module"},
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
+from collections.abc import Callable, Iterable
+
 import pytest
 
+from warc2zim.content_rewriting.css import CssRewriter
+from warc2zim.content_rewriting.js import JsRewriter
+from warc2zim.content_rewriting.rx_replacer import TransformationRule
 from warc2zim.url_rewriting import ArticleUrlRewriter, HttpUrl, ZimPath
 
 
@@ -47,3 +52,39 @@ def simple_url_rewriter():
         return SimpleUrlRewriter(HttpUrl(url))
 
     yield get_simple_url_rewriter
+
+
+@pytest.fixture(scope="module")
+def js_rewriter():
+    """Fixture to create a basic url rewriter returning URLs as-is"""
+
+    def get_js_rewriter(
+        url_rewriter: ArticleUrlRewriter,
+        base_href: str | None,
+        notify_js_module: Callable[[ZimPath], None],
+        extra_rules: Iterable[TransformationRule] | None = None,
+    ):
+        return JsRewriter(
+            url_rewriter=url_rewriter,
+            base_href=base_href,
+            notify_js_module=notify_js_module,
+            extra_rules=extra_rules,
+        )
+
+    yield get_js_rewriter
+
+
+@pytest.fixture(scope="module")
+def css_rewriter():
+    """Fixture to create a basic url rewriter returning URLs as-is"""
+
+    def get_css_rewriter(
+        url_rewriter: ArticleUrlRewriter,
+        base_href: str | None,
+    ):
+        return CssRewriter(
+            url_rewriter=url_rewriter,
+            base_href=base_href,
+        )
+
+    yield get_css_rewriter


### PR DESCRIPTION
Fix #305 

Idea: we should be able to define individual rewriting rules with functions and decorators, just like we do when defining endpoints in FastAPI. We have one decorator per kind of modification: drop attribute, rewrite attribute, rewrite data (and maybe others) and we implement one decorated function per kind of modifications expected.

Changes:
- new HTMLRewritingRules class with decorators `drop_attribute` (to decide to drop an HTML tag attribute), `rewrite_attribute` (to rewrite a given HTML tag attribute - name + value), `rewrite_tag` (to rewrite the whole HTML tag, potentially dropping it completely or changing tag name), `rewrite_data` (to rewrite HTML tag data)
- an instance of this class is wired in the html rewriting logic to properly process HTML code
- new tests are added to unit-test the new class behavior

See https://github.com/openzim/warc2zim/pull/353 for a show case of how this new code structure make it easier to:
- extend rewriting logic with support for new case
- test in isolation the extension, without having to deal with whole HTML tree