### PR TITLE
Correctly rewrite target url in HTML meta http-equiv redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New fuzzy-rule for cheatography.com (#342), der-postillon.com (#330)
 - Properly rewrite redirect target url when present in <meta> HTML tag (#237)
 
 ### Changed
@@ -34,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Exit with cleaner message when no entries are expected in the ZIM (#336) and when main entry is not processable (#337)
 - Add debug log for items whose content is empty (#344)
-- New fuzzy-rule for cheatography.com (#342), der-postillon.com (#330)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Properly rewrite redirect target url when present in <meta> HTML tag (#237)
+
 ### Changed
 
 - Generate fuzzy rules tests in Python and Javascript (#284)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Generate fuzzy rules tests in Python and Javascript (#284)
+- Refactor HTML rewriter class to make it more open to change and expressive (#305)
 
 ### Fixed
 

--- a/test-website/content/http-equiv-redirect.html
+++ b/test-website/content/http-equiv-redirect.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Test website</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="./icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="./icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="./icons/favicon-16x16.png">
+  <link rel="manifest" href="./icons/site.webmanifest">
+  <link rel="shortcut icon" href="./icons/favicon.ico">
+  <meta http-equiv="refresh" content="3;url=https://standard_netloc/index.html" />
+</head>
+
+<body>
+
+  <h2>Redirect with http-equiv meta directive</h2>
+
+  <p>You should be redirected to home page in 3 seconds</p>
+
+</body>
+
+</html>

--- a/test-website/content/index.html
+++ b/test-website/content/index.html
@@ -49,6 +49,7 @@
         <li><a href="./href-to-folder/">links to folder instead of file</a></li>
         <li><a href="./bad-redirections.html">Bad redirections</a></li>
         <li><a href="./content-types/index.html">Handling of content types</a></li>
+        <li><a href="./http-equiv-redirect.html">Redirect with http-equiv meta directive</a></li>
     </ul>
 </body>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,9 @@ def no_js_notify():
 class SimpleUrlRewriter(ArticleUrlRewriter):
     """Basic URL rewriter mocking most calls"""
 
-    def __init__(self, article_url: HttpUrl):
+    def __init__(self, article_url: HttpUrl, suffix: str = ""):
         self.article_url = article_url
+        self.suffix = suffix
 
     def __call__(
         self,
@@ -31,7 +32,7 @@ class SimpleUrlRewriter(ArticleUrlRewriter):
         *,
         rewrite_all_url: bool = True,  # noqa: ARG002
     ) -> str:
-        return item_url
+        return item_url + self.suffix
 
     def get_item_path(
         self, item_url: str, base_href: str | None  # noqa: ARG002
@@ -48,8 +49,8 @@ class SimpleUrlRewriter(ArticleUrlRewriter):
 def simple_url_rewriter():
     """Fixture to create a basic url rewriter returning URLs as-is"""
 
-    def get_simple_url_rewriter(url: str):
-        return SimpleUrlRewriter(HttpUrl(url))
+    def get_simple_url_rewriter(url: str, suffix: str = ""):
+        return SimpleUrlRewriter(HttpUrl(url), suffix=suffix)
 
     yield get_simple_url_rewriter
 


### PR DESCRIPTION
Fix #237 

Changes:
- properly rewrite redirect target url when present in `<meta>` HTML tag
- add test case in test website

Nota: this is built on-top of https://github.com/openzim/warc2zim/pull/343 and should hence be reviewed only once this is reviewed/merged