### PR TITLE
Source more ZIM metadata from WARC files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generate fuzzy rules tests in Python and Javascript (#284)
 - Refactor HTML rewriter class to make it more open to change and expressive (#305)
 - Detect charset in document header only for HTML documents (#331)
+- Use `software` property from `warcinfo` record to set ZIM `Scraper` metadata (#357)
+- Store `ContentDate` as metadata, based on `WARC-Date` (#358)
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "tinycss2==1.3.0",
   "beautifulsoup4==4.12.3", # used to parse base href
   "lxml==5.2.2", # used by beautifulsoup4 for parsing html
+  "python-dateutil==2.9.0.post0",
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
 

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -847,5 +847,5 @@ def iter_warc_records(warc_files):
     for filename in warc_files:
         with open(filename, "rb") as fh:
             for record in buffering_record_iter(ArchiveIterator(fh), post_append=True):
-                if record and record.rec_type in ("resource", "response", "revisit"):
+                if record:
                     yield record


### PR DESCRIPTION
Fix #358 
Fix #357 

Changes:
- in addition to changes needed by issues mentioned, we stop to filter warc records by type in the `iter_warc_records` generator since this is both confusing + needless ; selecting proper record type is the "using code" responsibility
and needs might vary