### PR TITLE
Remove double slash in URLs, both in Python and JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle case where the redirect target is bad / unsupported (#332 and #356)
 - Fixed WARC files handling order to follow creation order (#366)
+- Remove subsequent slashes in URLs, both in Python and JS (#365)
 
 ## [2.0.3] - 2024-07-24
 

--- a/javascript/src/wombatSetup.js
+++ b/javascript/src/wombatSetup.js
@@ -59,6 +59,12 @@ export function hasAlreadyBeenRewritten(
   return false;
 }
 
+function removeSubsequentSlashes(value) {
+  // Remove all successive occurrences of a slash `/` in a given string
+  // E.g `val//ue` or `val///ue` or `val////ue` (and so on) are transformed into `value`
+  return value.replace(/\/\/+/g, '/');
+}
+
 export function urlRewriteFunction(
   current_url, // The current (real) url we are on, e.g. http://library.kiwix.org/content/myzim_yyyy-mm/www.example.com/index.html
   orig_host, // The host of the original url, e.g. www.example.com
@@ -176,7 +182,8 @@ export function urlRewriteFunction(
       : '?' + decodeURIComponent(absolute_url_parts.query).replaceAll('+', ' ');
 
   // combine all decoded parts to get the ZIM path
-  const zimPath = decoded_host + decoded_path + decoded_query;
+  const zimPath =
+    decoded_host + removeSubsequentSlashes(decoded_path + decoded_query);
 
   // apply the fuzzy rules to the ZIM path
   const fuzzifiedPath = applyFuzzyRules(zimPath);

--- a/javascript/test/wombatUrlRewriting.js
+++ b/javascript/test/wombatUrlRewriting.js
@@ -1127,3 +1127,54 @@ test('relNotReallyAnotherHostAlreadyRewrittenNotUpEnough', (t) => {
     'http://library.kiwix.org/content/myzim_yyyy-mm/www.example.com/anotherhost.com/javascript/content.txt',
   );
 });
+
+test('doubleSlash1', (t) => {
+  t.is(
+    urlRewriteFunction(
+      t.context.currentUrl,
+      t.context.originalHost,
+      t.context.originalScheme,
+      t.context.originalUrl,
+      t.context.prefix,
+      'http://example.com/some/path/http://example.com//some/path',
+      undefined,
+      undefined,
+      undefined,
+    ),
+    'http://library.kiwix.org/content/myzim_yyyy-mm/example.com/some/path/http%3A/example.com/some/path',
+  );
+});
+
+test('doubleSlash2', (t) => {
+  t.is(
+    urlRewriteFunction(
+      t.context.currentUrl,
+      t.context.originalHost,
+      t.context.originalScheme,
+      t.context.originalUrl,
+      t.context.prefix,
+      'http://example.com/some/pa?th/http://example.com//some/path',
+      undefined,
+      undefined,
+      undefined,
+    ),
+    'http://library.kiwix.org/content/myzim_yyyy-mm/example.com/some/pa%3Fth/http%3A/example.com/some/path',
+  );
+});
+
+test('doubleSlash3', (t) => {
+  t.is(
+    urlRewriteFunction(
+      t.context.currentUrl,
+      t.context.originalHost,
+      t.context.originalScheme,
+      t.context.originalUrl,
+      t.context.prefix,
+      'http://example.com/so?me/pa?th/http://example.com//some/path',
+      undefined,
+      undefined,
+      undefined,
+    ),
+    'http://library.kiwix.org/content/myzim_yyyy-mm/example.com/so%3Fme/pa%3Fth/http%3A/example.com/some/path',
+  );
+});

--- a/src/warc2zim/url_rewriting.py
+++ b/src/warc2zim/url_rewriting.py
@@ -45,13 +45,7 @@ from __future__ import annotations
 
 import re
 from pathlib import PurePosixPath
-from urllib.parse import (
-    quote,
-    unquote,
-    urljoin,
-    urlsplit,
-    urlunsplit,
-)
+from urllib.parse import quote, unquote, urljoin, urlsplit, urlunsplit
 
 import idna
 
@@ -228,9 +222,19 @@ def normalize(url: HttpUrl) -> ZimPath:
     else:
         query = ""
 
-    fuzzified_url = apply_fuzzy_rules(f"{hostname}{path}{query}")
+    fuzzified_url = apply_fuzzy_rules(
+        f"{hostname}{_remove_subsequent_slashes(path)}{_remove_subsequent_slashes(query)}"
+    )
 
     return ZimPath(fuzzified_url)
+
+
+def _remove_subsequent_slashes(value: str) -> str:
+    """Remove all successive occurence of a slash `/` in a given string
+
+    E.g `val//ue` or `val///ue` or `val////ue` (and so on) are transformed into `value`
+    """
+    return re.sub(r"//+", "/", value)
 
 
 def get_without_fragment(url: str) -> str:

--- a/tests/test_warc_to_zim.py
+++ b/tests/test_warc_to_zim.py
@@ -270,15 +270,15 @@ class TestWarc2Zim:
             ("http://example.com/#anchor1", "example.com/"),
             (
                 "http://example.com/some/path/http://example.com//some/path",
-                "example.com/some/path/http://example.com//some/path",
+                "example.com/some/path/http:/example.com/some/path",
             ),
             (
                 "http://example.com/some/pa?th/http://example.com//some/path",
-                "example.com/some/pa?th/http://example.com//some/path",
+                "example.com/some/pa?th/http:/example.com/some/path",
             ),
             (
                 "http://example.com/so?me/pa?th/http://example.com//some/path",
-                "example.com/so?me/pa?th/http://example.com//some/path",
+                "example.com/so?me/pa?th/http:/example.com/some/path",
             ),
             ("http://example.com/resource?", "example.com/resource"),
             ("http://example.com/resource#", "example.com/resource"),
@@ -325,7 +325,7 @@ class TestWarc2Zim:
         ],
     )
     def test_normalize(self, url, zim_path):
-        assert normalize(HttpUrl(url)) == ZimPath(zim_path)
+        assert normalize(HttpUrl(url)).value == ZimPath(zim_path).value
 
     def test_warc_to_zim_specify_params_and_metadata(self, tmp_path):
         zim_output = "zim-out-filename.zim"


### PR DESCRIPTION
Fix #316 

Changes:
- in Python and in JS, when we compute the ZIM path from a given URL, we replace all multiple occurences of `/` character by a single `/`
  - both rely on a utility function which is not public, since not meant to be reused anywhere else is the codebase
- in Python test, compare `ZimPath` value instead of comparing object, from better pytest report in case of issue (string are compared char by char and error is quickly spotted)