### PR TITLE
Properly sort WARC files and log total number of WARCs found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Handle case where the redirect target is bad / unsupported (#332 and #356)
+- Fixed WARC files handling order to follow creation order (#366)
 
 ## [2.0.3] - 2024-07-24
 

--- a/src/warc2zim/main.py
+++ b/src/warc2zim/main.py
@@ -8,7 +8,7 @@ from warc2zim.converter import Converter
 from warc2zim.utils import get_version
 
 
-def main(raw_args=None):
+def _create_arguments_parser() -> ArgumentParser:
     parser = ArgumentParser(description="Create ZIM files from WARC files")
 
     parser.add_argument("-V", "--version", action="version", version=get_version())
@@ -141,6 +141,11 @@ def main(raw_args=None):
         default=False,
     )
 
+    return parser
+
+
+def main(raw_args=None):
+    parser = _create_arguments_parser()
     args = parser.parse_args(args=raw_args)
     converter = Converter(args)
     return converter.run()

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,52 @@
+import tempfile
+
+import pytest
+
+from warc2zim.converter import Converter
+from warc2zim.main import _create_arguments_parser
+
+
+@pytest.mark.parametrize(
+    "inputs, warc_files",
+    [
+        pytest.param([], [], id="empty_array"),
+        pytest.param(["foo.warc.gz"], ["foo.warc.gz"], id="one_file"),
+        pytest.param(
+            [
+                "rec-f9c30d949953-20240724035746176-0.warc.gz",
+                "rec-f9c30d949953-20240724045846176-0.warc.gz",
+            ],
+            None,  # no change
+            id="two_already_sorted",
+        ),
+        pytest.param(
+            [
+                "rec-f9c30d949953-20240724045846176-0.warc.gz",
+                "rec-f9c30d949953-20240724035746176-0.warc.gz",
+            ],
+            [
+                "rec-f9c30d949953-20240724035746176-0.warc.gz",
+                "rec-f9c30d949953-20240724045846176-0.warc.gz",
+            ],
+            id="two_not_sorted",
+        ),
+        pytest.param(
+            [
+                "aaaa/rec-f9c30d949953-20240724045846176-0.warc.gz",
+                "bbb/rec-f9c30d949953-20240724035746176-0.warc.gz",
+            ],
+            [
+                "bbb/rec-f9c30d949953-20240724035746176-0.warc.gz",
+                "aaaa/rec-f9c30d949953-20240724045846176-0.warc.gz",
+            ],
+            id="two_not_sorted_in_random_unsorted_dirs",
+        ),
+    ],
+)
+def test_sort_warc_files(inputs, warc_files):
+    parser = _create_arguments_parser()
+    tmpdir = tempfile.mkdtemp()
+    args = parser.parse_args(["--name", "foo", "--output", tmpdir])
+    args.inputs = inputs
+    conv = Converter(args)
+    assert conv.warc_files == (warc_files if warc_files else inputs)


### PR DESCRIPTION
Fix #360 

Changes:
- compute and sort the list of WARC files at converter startup, so that it is done only once no matter the number of times `iter_warc_records` is called
- log total number of WARC files