### PR TITLE
Cache HTML rewriting function signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove subsequent slashes in URLs, both in Python and JS (#365)
 - Ignore non HTTP(S) WARC records (#351)
 - Fix `vimeo_cdn_fix` fuzzy rule for proper operation in Javascript (#348)
+- Performance issue linked to new "extensible" HTML rewriting rules (#370)
 
 ## [2.0.3] - 2024-07-24
 


### PR DESCRIPTION
This PR replaces https://github.com/openzim/warc2zim/pull/371 with another approach based on `@lru_cache`

Fix https://github.com/openzim/warc2zim/issues/370

Changes:
- use `@cache` (an `@lru_cache` without max size since we want to cache all values) to cache rewriting rule function signature
