### PR TITLE
Use main branch of python-scraperlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL org.opencontainers.image.source=https://github.com/openzim/warc2zim
 
 RUN apt-get update -y \
  && apt-get install -y --no-install-recommends \
-    locales-all libmagic1 libcairo2 \
+    locales-all libmagic1 libcairo2 git \
  && rm -rf /var/lib/apt/lists/* \
  && python -m pip install --no-cache-dir -U \
       pip \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 dependencies = [
   "warcio==1.7.5",
   "requests==2.32.5",
-  "zimscraperlib==5.3.0",
+  "zimscraperlib @ git+https://github.com/openzim/python-scraperlib@main",
   "jinja2==3.1.6",
   # to support possible brotli content in warcs, must be added separately
   "brotlipy==0.7.0",
@@ -21,6 +21,9 @@ dependencies = [
   "multipart==1.3.0",
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
+
+[tool.hatch.metadata]
+allow-direct-references = true  # to be removed once we use a released warc2zim version
 
 [tool.hatch.metadata.hooks.openzim-metadata]
 kind = "scraper"


### PR DESCRIPTION
For development purpose, we should aim to use `main` branch from zimscraperlib until this has settled and we've confirmed the whole chain up to zimit works as expected