### PR TITLE
New flag to try known charsets when bad encoding is specified in HTTP or HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `--ignore-unknown-charsets` flag to try known charsets when bad encoding is specified in HTTP or HTML (#xxx)
+
 ## [2.3.0] - 2026-01-21
 
 ### Added

--- a/src/warc2zim/converter.py
+++ b/src/warc2zim/converter.py
@@ -51,12 +51,14 @@ from zimscraperlib.types import FALLBACK_MIME
 from zimscraperlib.zim import metadata
 from zimscraperlib.zim.creator import Creator
 
+import warc2zim.utils as warc2zim_utils
 from warc2zim.cdxj_indexer import buffering_record_iter, iter_file_or_dir
 from warc2zim.constants import logger
 from warc2zim.icon_finder import Icon, get_sorted_icons, icons_in_html
 from warc2zim.items import StaticArticle, StaticFile, WARCPayloadItem
 from warc2zim.language import parse_language
 from warc2zim.utils import (
+    UNKNOWN_ENCODINGS,
     can_process_status_code,
     get_record_content,
     get_record_mime_type,
@@ -250,6 +252,7 @@ class Converter:
         self.disable_metadata_checks = bool(args.disable_metadata_checks)
         self.ignore_content_header_charsets = bool(args.ignore_content_header_charsets)
         self.ignore_http_header_charsets = bool(args.ignore_http_header_charsets)
+        warc2zim_utils.IGNORE_UNKNOWN_CHARSETS = bool(args.ignore_unknown_charsets)
 
     def update_stats(self):
         """write progress as JSON to self.stats_filename if requested"""
@@ -457,6 +460,12 @@ class Converter:
                 self.added_zim_items.add(normalized_url)
 
         logger.debug(f"Found {self.total_records} records in WARCs")
+
+        if UNKNOWN_ENCODINGS:
+            logger.warning(
+                f"Unknown encodings have been encoutered:\n- "
+                f"{'\n- '.join(UNKNOWN_ENCODINGS)}"
+            )
 
         self.creator.finish()
 

--- a/src/warc2zim/main.py
+++ b/src/warc2zim/main.py
@@ -142,6 +142,14 @@ def _create_arguments_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
+        "--ignore-unknown-charsets",
+        help="When encountering an unknown charsets content or HTTP header, do not fail"
+        " but try --charsets-to-try for potential match",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
         "--encoding-aliases",
         help="List of encoding/charset aliases to decode WARC content. Aliases are used"
         " when the encoding specified in upstream server exists in Python under a"

--- a/src/warc2zim/utils.py
+++ b/src/warc2zim/utils.py
@@ -31,6 +31,8 @@ DEFAULT_ENCODING_ALIASES = {
 }
 
 ENCODING_ALIASES = {}
+UNKNOWN_ENCODINGS: set[str] = set()
+IGNORE_UNKNOWN_CHARSETS = False
 
 
 def set_encoding_aliases(aliases: dict[str, str]):
@@ -200,14 +202,27 @@ def to_string(
             )
             if m := ENCODING_RE.search(content_start):
                 head_encoding = m.group("encoding")
-                return input_.decode(
-                    get_encoding_by_alias(head_encoding),
-                    errors="replace",
-                )
+                head_encoding_aliased = get_encoding_by_alias(head_encoding)
+                try:
+                    return input_.decode(head_encoding_aliased, errors="replace")
+                except (ValueError, LookupError):
+                    if IGNORE_UNKNOWN_CHARSETS:
+                        UNKNOWN_ENCODINGS.add(head_encoding_aliased)
+                        pass
+                    else:
+                        raise
 
-    # Search for encofing in HTTP `Content-Type` header
+    # Search for encoding in HTTP `Content-Type` header
     if not ignore_http_header_charsets and http_encoding:
-        return input_.decode(get_encoding_by_alias(http_encoding), errors="replace")
+        http_encoding_aliased = get_encoding_by_alias(http_encoding)
+        try:
+            return input_.decode(http_encoding_aliased, errors="replace")
+        except (ValueError, LookupError):
+            if IGNORE_UNKNOWN_CHARSETS:
+                UNKNOWN_ENCODINGS.add(http_encoding_aliased)
+                pass
+            else:
+                raise
 
     # Try all charsets_to_try passed
     for charset_to_try in charsets_to_try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,15 @@ from pathlib import Path
 
 import pytest
 
+import warc2zim.utils as warc2zim_utils
 from warc2zim.utils import get_encoding_by_alias, set_encoding_aliases, to_string
+
+
+@pytest.fixture
+def ignore_unknown_encoding():
+    warc2zim_utils.IGNORE_UNKNOWN_CHARSETS = True
+    yield
+    warc2zim_utils.IGNORE_UNKNOWN_CHARSETS = False
 
 
 @dataclass
@@ -361,6 +369,40 @@ def test_decode_charset_too_far_away_without_proper_alias():
             ignore_http_header_charsets=False,
             ignore_content_header_charsets=False,
         )
+
+
+def test_decode_charset_with_ignore_unknown_encodings(
+    ignore_unknown_encoding,  # noqa: ARG001
+):
+    content = '<html><meta charset="foo"><body>content</body></html>'
+    set_encoding_aliases({"bar": "latin1"})
+    with pytest.raises(ValueError, match="No suitable charset found"):
+        to_string(
+            content.encode("latin1"),
+            None,
+            [],
+            1024,
+            ignore_http_header_charsets=False,
+            ignore_content_header_charsets=False,
+        )
+
+
+def test_decode_charset_with_ignore_unknown_encodings_charsets_to_try(
+    ignore_unknown_encoding,  # noqa: ARG001
+):
+    content = '<html><meta charset="foo"><body>content</body></html>'
+    set_encoding_aliases({"bar": "latin1"})
+    assert (
+        to_string(
+            content.encode("latin1"),
+            None,
+            ["utf-8"],
+            1024,
+            ignore_http_header_charsets=False,
+            ignore_content_header_charsets=False,
+        )
+        == content
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR introduces a new `--ignore-unknown-charsets` flag which allows warc2zim to ignore charset found in HTTP headers or HTML <head> if it fails to decode because it is unknown.

When this happens, currently the scraper is just halted for typically stupid reasons like in https://farm.openzim.org/pipeline/71c03b16-124d-4ee1-ac22-218c2a1392a1

```
LookupError: unknown encoding: utf-4
```

When such an error occurs, it is probably worth to try to decode with `--charsets-to-try` values.

Unknown encodings are stored so they are reported at the end, giving a chance to fix them in next invocations.