### PR TITLE
Do not crash on a non-numeric HTTP status in get_status_code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not crash on a WARC response record with a non-numeric HTTP status token; `get_status_code` now ignores it like other invalid statuses instead of raising an uncaught `ValueError` that aborted the whole conversion
+
 ## [2.3.1] - 2026-07-31
 
 ### Added

--- a/src/warc2zim/utils.py
+++ b/src/warc2zim/utils.py
@@ -73,7 +73,12 @@ def get_status_code(record: ArcWarcRecord) -> HTTPStatus | int | None:
         # null / missing http status found, ignore it
         return None
 
-    status_code = int(status_code)
+    try:
+        status_code = int(status_code)
+    except ValueError:
+        # non-numeric http status found, ignore it (happens when a corrupt / non
+        # HTTP-compliant status line is captured, e.g. "HTTP/1.1 tea")
+        return None
 
     try:
         status_code = HTTPStatus(status_code)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,21 @@
+import io
 import json
 from collections.abc import Generator
 from dataclasses import dataclass
+from http import HTTPStatus
 from pathlib import Path
 
 import pytest
+from warcio import StatusAndHeaders
+from warcio.recordloader import ArcWarcRecord
 
 import warc2zim.utils as warc2zim_utils
-from warc2zim.utils import get_encoding_by_alias, set_encoding_aliases, to_string
+from warc2zim.utils import (
+    get_encoding_by_alias,
+    get_status_code,
+    set_encoding_aliases,
+    to_string,
+)
 
 
 @pytest.fixture
@@ -442,3 +451,46 @@ def test_get_unknown_encoding():
 def test_override_default_encoding_alias(alias, expected):
     set_encoding_aliases({"unicode": "latin1"})
     assert get_encoding_by_alias(alias) == expected
+
+
+def _make_response_record(status: str) -> ArcWarcRecord:
+    """Build a minimal 'response' ArcWarcRecord with the given HTTP status.
+
+    ``status`` is the status line without the protocol (the way warcio stores it
+    when parsing a WARC), e.g. "200 OK" or "tea I'm a teapot".
+    """
+    rec_headers = StatusAndHeaders(
+        "WARC/1.1",
+        headers=[("WARC-Target-URI", "http://www.example.com")],
+    )
+    http_headers = StatusAndHeaders(
+        status,
+        headers=[("Content-Type", "text/html")],
+        protocol="HTTP/1.1",
+    )
+    return ArcWarcRecord(
+        "warc",
+        "response",
+        rec_headers,
+        io.BytesIO(b"dummy"),
+        http_headers,
+        "application/http; msgtype=response",
+        len(b"dummy"),
+    )
+
+
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        ("200 OK", HTTPStatus.OK),
+        # numeric but not a known HTTPStatus member -> returned as-is (int)
+        ("306 Switch Proxy", 306),
+        # non-numeric / corrupt status token -> ignored gracefully, not a crash
+        ("tea I'm a teapot", None),
+        ("OK", None),
+    ],
+)
+def test_get_status_code_handles_non_numeric_status(status, expected):
+    # Regression: a non-numeric HTTP status token used to raise an uncaught
+    # ValueError from int(status_code), aborting the whole conversion.
+    assert get_status_code(_make_response_record(status)) == expected


### PR DESCRIPTION
While reading how `get_status_code` handles unusual HTTP statuses, I noticed the numeric conversion isn't fully guarded.

The function already tolerates bad statuses in two places: it returns `None` for a missing/empty status, and it catches `ValueError` from `HTTPStatus(...)` to ignore numeric-but-unsupported codes like `0` or `306`. But the `status_code = int(status_code)` step in between is unguarded. If a WARC `response` record's HTTP status line carries a non-numeric token (a corrupt capture, or a non-compliant origin server), `int()` raises an uncaught `ValueError`.

`get_status_code` runs for every response/revisit record in `gather_information_from_warc()`, and `run()` only wraps that in a handler for `UnprocessableWarcError`, so the `ValueError` propagates all the way out and aborts the whole ZIM build — a single malformed record kills the conversion.

This guards the `int()` conversion and returns `None` for a non-numeric status, matching the function's existing intent to ignore invalid statuses. Added a regression test covering valid, numeric-but-unsupported, and non-numeric status tokens.
